### PR TITLE
fix: avoid main.sync deadlock on permissionChanges cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add immutable per-request accessibility traversal options while keeping the legacy process defaults source-compatible and thread-safe.
 
 ### Fixed
+- Stop `permissionChanges()` from synchronously hopping to the main queue during cancellation, so canceling the stream cannot deadlock against a busy main thread.
 - Refuse per-element Accessibility reads when macOS cannot arm their messaging deadline, and report any failure to clear an armed deadline after the protected operation.
 - Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications` and application readiness, keep observer creation, registration, and cleanup deadline-bounded off the main actor so a wedged app cannot block startup or teardown, retain semantic application identity across wrapper churn, reset shared observers with unprivileged process-unique identities across PID reuse, recover boundedly from transient registration failures, and reject the invalid PID-zero observer path.
 - Resolve point-owned applications from one native on-screen window snapshot, avoiding synchronous all-app Accessibility queries while keeping frontmost fallback limited to the compatibility API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ All notable changes to AXorcist will be documented in this file.
 - Add immutable per-request accessibility traversal options while keeping the legacy process defaults source-compatible and thread-safe.
 
 ### Fixed
-- Stop `permissionChanges()` from synchronously hopping to the main queue during cancellation, so canceling the stream cannot deadlock against a busy main thread.
 - Refuse per-element Accessibility reads when macOS cannot arm their messaging deadline, and report any failure to clear an armed deadline after the protected operation.
 - Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications` and application readiness, keep observer creation, registration, and cleanup deadline-bounded off the main actor so a wedged app cannot block startup or teardown, retain semantic application identity across wrapper churn, reset shared observers with unprivileged process-unique identities across PID reuse, recover boundedly from transient registration failures, and reject the invalid PID-zero observer path.
 - Resolve point-owned applications from one native on-screen window snapshot, avoiding synchronous all-app Accessibility queries while keeping frontmost fallback limited to the compatibility API.

--- a/Sources/AXorcist/Core/AXPermissionHelpers.swift
+++ b/Sources/AXorcist/Core/AXPermissionHelpers.swift
@@ -128,15 +128,24 @@ public enum AXPermissionHelpers {
     public static func permissionChanges(
         interval: TimeInterval = 1.0) -> AsyncStream<Bool>
     {
+        self.permissionChanges(interval: interval, onTimerScheduled: nil)
+    }
+
+    nonisolated static func permissionChanges(
+        interval: TimeInterval,
+        onTimerScheduled: (@MainActor () -> Void)?) -> AsyncStream<Bool>
+    {
         AsyncStream { continuation in
             // Use a class to hold the timer and state to avoid capture issues
             final class TimerBox: @unchecked Sendable {
                 var timer: Timer?
                 var lastState: Bool?
+                var terminated = false
             }
             let timerBox = TimerBox()
 
             let start: @MainActor () -> Void = {
+                guard !timerBox.terminated else { return }
                 let initialState = self.hasAccessibilityPermissions()
                 timerBox.lastState = initialState
                 continuation.yield(initialState)
@@ -149,10 +158,12 @@ public enum AXPermissionHelpers {
                         continuation.yield(currentState)
                     }
                 }
+                onTimerScheduled?()
             }
             Self.hopToMainActor(start)
 
             continuation.onTermination = { @Sendable _ in
+                timerBox.terminated = true
                 Self.hopToMainActor {
                     timerBox.timer?.invalidate()
                     timerBox.timer = nil

--- a/Sources/AXorcist/Core/AXPermissionHelpers.swift
+++ b/Sources/AXorcist/Core/AXPermissionHelpers.swift
@@ -129,25 +129,19 @@ public enum AXPermissionHelpers {
         interval: TimeInterval = 1.0) -> AsyncStream<Bool>
     {
         AsyncStream { continuation in
-            let initialState = Self.syncOnMainActor {
-                self.hasAccessibilityPermissions()
-            }
-            continuation.yield(initialState)
-
             // Use a class to hold the timer and state to avoid capture issues
             final class TimerBox: @unchecked Sendable {
                 var timer: Timer?
-                var lastState: Bool
-
-                init(initialState: Bool) {
-                    self.lastState = initialState
-                }
+                var lastState: Bool?
             }
-            let timerBox = TimerBox(initialState: initialState)
+            let timerBox = TimerBox()
 
-            Self.syncOnMainActor {
+            let start: @MainActor () -> Void = {
+                let initialState = self.hasAccessibilityPermissions()
+                timerBox.lastState = initialState
+                continuation.yield(initialState)
                 timerBox.timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
-                    let currentState = Self.syncOnMainActor {
+                    let currentState = MainActor.assumeIsolated {
                         self.hasAccessibilityPermissions()
                     }
                     if currentState != timerBox.lastState {
@@ -156,9 +150,10 @@ public enum AXPermissionHelpers {
                     }
                 }
             }
+            Self.hopToMainActor(start)
 
             continuation.onTermination = { @Sendable _ in
-                Self.syncOnMainActor {
+                Self.hopToMainActor {
                     timerBox.timer?.invalidate()
                     timerBox.timer = nil
                 }
@@ -167,13 +162,12 @@ public enum AXPermissionHelpers {
     }
 
     @inline(__always)
-    private nonisolated static func syncOnMainActor<Value: Sendable>(
-        _ work: @MainActor () -> Value) -> Value
-    {
+    private nonisolated static func hopToMainActor(_ work: @escaping @MainActor () -> Void) {
         if Thread.isMainThread {
-            return MainActor.assumeIsolated(work)
+            MainActor.assumeIsolated(work)
+            return
         }
-        return DispatchQueue.main.sync {
+        DispatchQueue.main.async {
             MainActor.assumeIsolated(work)
         }
     }

--- a/Sources/AXorcist/Core/AXPermissionHelpers.swift
+++ b/Sources/AXorcist/Core/AXPermissionHelpers.swift
@@ -138,14 +138,27 @@ public enum AXPermissionHelpers {
         AsyncStream { continuation in
             // Use a class to hold the timer and state to avoid capture issues
             final class TimerBox: @unchecked Sendable {
+                private let lock = NSLock()
                 var timer: Timer?
                 var lastState: Bool?
-                var terminated = false
+                private var terminatedFlag = false
+
+                var isTerminated: Bool {
+                    self.lock.lock()
+                    defer { self.lock.unlock() }
+                    return self.terminatedFlag
+                }
+
+                func markTerminated() {
+                    self.lock.lock()
+                    self.terminatedFlag = true
+                    self.lock.unlock()
+                }
             }
             let timerBox = TimerBox()
 
             let start: @MainActor () -> Void = {
-                guard !timerBox.terminated else { return }
+                guard !timerBox.isTerminated else { return }
                 let initialState = self.hasAccessibilityPermissions()
                 timerBox.lastState = initialState
                 continuation.yield(initialState)
@@ -163,7 +176,7 @@ public enum AXPermissionHelpers {
             Self.hopToMainActor(start)
 
             continuation.onTermination = { @Sendable _ in
-                timerBox.terminated = true
+                timerBox.markTerminated()
                 Self.hopToMainActor {
                     timerBox.timer?.invalidate()
                     timerBox.timer = nil

--- a/Tests/AXorcistTests/PermissionChangeStreamTests.swift
+++ b/Tests/AXorcistTests/PermissionChangeStreamTests.swift
@@ -16,6 +16,17 @@ nonisolated struct PermissionChangeStreamTests {
         #expect(completed)
     }
 
+    @Test
+    func `permissionChanges skip start after an already-terminated stream`() async {
+        let scheduled = PermissionTimerScheduleBox()
+        let skipped = await Task.detached {
+            Self.cancelBeforeQueuedStartRuns(scheduled: scheduled)
+        }.value
+
+        #expect(skipped)
+        #expect(!scheduled.wasMarked)
+    }
+
     private nonisolated static func cancelCompletesWhileMainQueueIsBusy(
         stream: AsyncStream<Bool>) -> Bool
     {
@@ -39,5 +50,49 @@ nonisolated struct PermissionChangeStreamTests {
         let finished = consumeFinished.wait(timeout: .now() + .milliseconds(400)) == .success
         releaseMain.signal()
         return finished
+    }
+
+    private nonisolated static func cancelBeforeQueuedStartRuns(
+        scheduled: PermissionTimerScheduleBox) -> Bool
+    {
+        let mainHeld = DispatchSemaphore(value: 0)
+        let streamCreated = DispatchSemaphore(value: 0)
+        let releaseMain = DispatchSemaphore(value: 0)
+
+        DispatchQueue.main.async {
+            mainHeld.signal()
+            streamCreated.wait()
+            releaseMain.wait()
+        }
+        mainHeld.wait()
+
+        _ = AXPermissionHelpers.permissionChanges(interval: 60) {
+            scheduled.mark()
+        }
+        streamCreated.signal()
+        releaseMain.signal()
+        let flushed = DispatchSemaphore(value: 0)
+        DispatchQueue.main.async {
+            flushed.signal()
+        }
+        flushed.wait()
+        return !scheduled.wasMarked
+    }
+}
+
+private final nonisolated class PermissionTimerScheduleBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var marked = false
+
+    func mark() {
+        self.lock.lock()
+        self.marked = true
+        self.lock.unlock()
+    }
+
+    var wasMarked: Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.marked
     }
 }

--- a/Tests/AXorcistTests/PermissionChangeStreamTests.swift
+++ b/Tests/AXorcistTests/PermissionChangeStreamTests.swift
@@ -9,9 +9,9 @@ nonisolated struct PermissionChangeStreamTests {
         let stream = await MainActor.run {
             AXPermissionHelpers.permissionChanges(interval: 60)
         }
-        let completed = await Task.detached {
+        let completed = await Self.runOnDedicatedThread {
             Self.cancelCompletesWhileMainQueueIsBusy(stream: stream)
-        }.value
+        }
 
         #expect(completed)
     }
@@ -19,9 +19,9 @@ nonisolated struct PermissionChangeStreamTests {
     @Test
     func `permissionChanges skip start after an already-terminated stream`() async {
         let scheduled = PermissionTimerScheduleBox()
-        let skipped = await Task.detached {
+        let skipped = await Self.runOnDedicatedThread {
             Self.cancelBeforeQueuedStartRuns(scheduled: scheduled)
-        }.value
+        }
 
         #expect(skipped)
         #expect(!scheduled.wasMarked)
@@ -77,6 +77,16 @@ nonisolated struct PermissionChangeStreamTests {
         }
         flushed.wait()
         return !scheduled.wasMarked
+    }
+
+    private nonisolated static func runOnDedicatedThread<Value: Sendable>(
+        _ operation: @escaping @Sendable () -> Value) async -> Value
+    {
+        await withCheckedContinuation { continuation in
+            Thread.detachNewThread {
+                continuation.resume(returning: operation())
+            }
+        }
     }
 }
 

--- a/Tests/AXorcistTests/PermissionChangeStreamTests.swift
+++ b/Tests/AXorcistTests/PermissionChangeStreamTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import AXorcist
+
+@Suite("Permission change stream")
+nonisolated struct PermissionChangeStreamTests {
+    @Test
+    func `permissionChanges cancel does not join the main queue`() async {
+        let stream = await MainActor.run {
+            AXPermissionHelpers.permissionChanges(interval: 60)
+        }
+        let completed = await Task.detached {
+            Self.cancelCompletesWhileMainQueueIsBusy(stream: stream)
+        }.value
+
+        #expect(completed)
+    }
+
+    private nonisolated static func cancelCompletesWhileMainQueueIsBusy(
+        stream: AsyncStream<Bool>) -> Bool
+    {
+        let consumeFinished = DispatchSemaphore(value: 0)
+        let consume = Task.detached {
+            for await _ in stream {}
+            consumeFinished.signal()
+        }
+
+        let mainHeld = DispatchSemaphore(value: 0)
+        let releaseMain = DispatchSemaphore(value: 0)
+        DispatchQueue.main.async {
+            mainHeld.signal()
+            releaseMain.wait()
+        }
+        mainHeld.wait()
+
+        Thread.detachNewThread {
+            consume.cancel()
+        }
+        let finished = consumeFinished.wait(timeout: .now() + .milliseconds(400)) == .success
+        releaseMain.signal()
+        return finished
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

`AXPermissionHelpers.permissionChanges()` scheduled its timer and invalidated it through `DispatchQueue.main.sync`. When the stream is cancelled off the main thread while the main queue is busy (a common case when a MainActor caller is waiting on that cancellation), `onTermination` hops off-main and then tries to join the main queue. The caller waits for termination. Termination waits for the main queue. The process hangs.

This is the same class of defect Peter Steinberger closed in [Peekaboo #225](https://github.com/openclaw/Peekaboo/pull/225): do not use `DispatchQueue.main.sync` for shared MainActor work. The follow-up that landed was [Peekaboo #253](https://github.com/openclaw/Peekaboo/pull/253) (inline `assumeIsolated` on the main thread, async hop otherwise).

## Evidence

Live `swift run` against the patched `AXorcist` product, not a mirrored helper. The driver creates `AXPermissionHelpers.permissionChanges()`, holds `DispatchQueue.main`, then cancels the consumer from a background thread.

```console
$ cd /tmp/prove-ax-sync && swift run
Building for debugging...
Build of product 'prove-ax-sync' complete! (0.51s)
cancel_completed=true
```

Unpatched `main.sync` never prints `cancel_completed=true` (the join blocks until the process is killed). After the hop, cancel returns while main is still held.

Production helper no longer contains `DispatchQueue.main.sync`:

```console
$ rg -n "DispatchQueue.main" Sources/AXorcist/Core/AXPermissionHelpers.swift
170:        DispatchQueue.main.async {
```

## Real behavior proof

- **Behavior or issue addressed:** `permissionChanges()` cancel no longer deadlocks when `onTermination` runs off-main against a busy main queue.
- **Real environment tested:** macOS 26, Apple Swift 6.3.3, patched AXorcist at `/tmp/oc-impl-axorcist-sync` (branch `fix/permission-changes-main-sync`).
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/prove-ax-sync
  swift run
  rg -n "DispatchQueue.main" /tmp/oc-impl-axorcist-sync/Sources/AXorcist/Core/AXPermissionHelpers.swift
  ```

- **Evidence after fix:** terminal output from the patched library:

  ```console
  $ swift run
  cancel_completed=true
  ```

  ```console
  $ rg -n "DispatchQueue.main" Sources/AXorcist/Core/AXPermissionHelpers.swift
  170:        DispatchQueue.main.async {
  ```

- **Observed result after fix:** The public stream finishes cancel while the main queue is blocked. The only remaining main-queue hop is `async`, so cancel cannot join a busy main thread.
- **What was not tested:** A live TCC permission flip while the stream is running (this change only covers construction and cancellation hops).

## Summary

Replace `syncOnMainActor` with `hopToMainActor`: `MainActor.assumeIsolated` when already on the main thread, `DispatchQueue.main.async` otherwise. Timer start and `onTermination` cleanup both use that hop. Public API of `permissionChanges(interval:)` is unchanged.

Introduced in [`d87f554`](https://github.com/openclaw/AXorcist/commit/d87f5543808f67da2c348f6de4996ed8bbc47ced) (2025-11-12, Peekaboo sync) and present for 276 days.

Related: [Peekaboo #225](https://github.com/openclaw/Peekaboo/pull/225) (closed; do not `main.sync`), [Peekaboo #253](https://github.com/openclaw/Peekaboo/pull/253) (landed hop).
