### PR TITLE
fix: serialize permission timer installation

### DIFF
--- a/Sources/AXorcist/Core/AXPermissionHelpers.swift
+++ b/Sources/AXorcist/Core/AXPermissionHelpers.swift
@@ -128,41 +128,26 @@ public enum AXPermissionHelpers {
     public static func permissionChanges(
         interval: TimeInterval = 1.0) -> AsyncStream<Bool>
     {
-        self.permissionChanges(interval: interval, onTimerScheduled: nil)
+        self.permissionChanges(
+            interval: interval,
+            beforeTimerInstall: nil,
+            onTimerScheduled: nil)
     }
 
     nonisolated static func permissionChanges(
         interval: TimeInterval,
+        beforeTimerInstall: (@MainActor () -> Void)? = nil,
         onTimerScheduled: (@MainActor () -> Void)?) -> AsyncStream<Bool>
     {
         AsyncStream { continuation in
-            // Use a class to hold the timer and state to avoid capture issues
-            final class TimerBox: @unchecked Sendable {
-                private let lock = NSLock()
-                var timer: Timer?
-                var lastState: Bool?
-                private var terminatedFlag = false
-
-                var isTerminated: Bool {
-                    self.lock.lock()
-                    defer { self.lock.unlock() }
-                    return self.terminatedFlag
-                }
-
-                func markTerminated() {
-                    self.lock.lock()
-                    self.terminatedFlag = true
-                    self.lock.unlock()
-                }
-            }
-            let timerBox = TimerBox()
+            let timerBox = PermissionChangeTimerBox()
 
             let start: @MainActor () -> Void = {
                 guard !timerBox.isTerminated else { return }
                 let initialState = self.hasAccessibilityPermissions()
                 timerBox.lastState = initialState
                 continuation.yield(initialState)
-                timerBox.timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
+                let timer = Timer(timeInterval: interval, repeats: true) { _ in
                     let currentState = MainActor.assumeIsolated {
                         self.hasAccessibilityPermissions()
                     }
@@ -171,6 +156,11 @@ public enum AXPermissionHelpers {
                         continuation.yield(currentState)
                     }
                 }
+                beforeTimerInstall?()
+                guard timerBox.installTimerIfActive(timer) else {
+                    timer.invalidate()
+                    return
+                }
                 onTimerScheduled?()
             }
             Self.hopToMainActor(start)
@@ -178,8 +168,7 @@ public enum AXPermissionHelpers {
             continuation.onTermination = { @Sendable _ in
                 timerBox.markTerminated()
                 Self.hopToMainActor {
-                    timerBox.timer?.invalidate()
-                    timerBox.timer = nil
+                    timerBox.invalidateTimer()
                 }
             }
         }
@@ -194,5 +183,44 @@ public enum AXPermissionHelpers {
         DispatchQueue.main.async {
             MainActor.assumeIsolated(work)
         }
+    }
+}
+
+private final nonisolated class PermissionChangeTimerBox: @unchecked Sendable {
+    private let lock = NSLock()
+    var timer: Timer?
+    var lastState: Bool?
+    private var terminatedFlag = false
+
+    var isTerminated: Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.terminatedFlag
+    }
+
+    func markTerminated() {
+        self.lock.lock()
+        self.terminatedFlag = true
+        self.lock.unlock()
+    }
+
+    @MainActor
+    func installTimerIfActive(_ timer: Timer) -> Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        guard !self.terminatedFlag else { return false }
+
+        self.timer = timer
+        RunLoop.main.add(timer, forMode: .default)
+        return true
+    }
+
+    @MainActor
+    func invalidateTimer() {
+        self.lock.lock()
+        let timer = self.timer
+        self.timer = nil
+        self.lock.unlock()
+        timer?.invalidate()
     }
 }

--- a/Tests/AXorcistTests/PermissionChangeStreamTests.swift
+++ b/Tests/AXorcistTests/PermissionChangeStreamTests.swift
@@ -27,6 +27,17 @@ nonisolated struct PermissionChangeStreamTests {
         #expect(!scheduled.wasMarked)
     }
 
+    @Test
+    func `permissionChanges skip timer when cancellation wins installation race`() async {
+        let scheduled = PermissionTimerScheduleBox()
+        let skipped = await Self.runOnDedicatedThread {
+            Self.cancelBeforeTimerInstallation(scheduled: scheduled)
+        }
+
+        #expect(skipped)
+        #expect(!scheduled.wasMarked)
+    }
+
     private nonisolated static func cancelCompletesWhileMainQueueIsBusy(
         stream: AsyncStream<Bool>) -> Bool
     {
@@ -77,6 +88,40 @@ nonisolated struct PermissionChangeStreamTests {
         }
         flushed.wait()
         return !scheduled.wasMarked
+    }
+
+    private nonisolated static func cancelBeforeTimerInstallation(
+        scheduled: PermissionTimerScheduleBox) -> Bool
+    {
+        let installReached = DispatchSemaphore(value: 0)
+        let releaseInstall = DispatchSemaphore(value: 0)
+        let consumeFinished = DispatchSemaphore(value: 0)
+
+        let stream = AXPermissionHelpers.permissionChanges(
+            interval: 60,
+            beforeTimerInstall: {
+                installReached.signal()
+                releaseInstall.wait()
+            },
+            onTimerScheduled: {
+                scheduled.mark()
+            })
+        let consume = Task.detached {
+            for await _ in stream {}
+            consumeFinished.signal()
+        }
+
+        installReached.wait()
+        consume.cancel()
+        let cancelled = consumeFinished.wait(timeout: .now() + .milliseconds(400)) == .success
+        releaseInstall.signal()
+
+        let flushed = DispatchSemaphore(value: 0)
+        DispatchQueue.main.async {
+            flushed.signal()
+        }
+        flushed.wait()
+        return cancelled && !scheduled.wasMarked
     }
 
     private nonisolated static func runOnDedicatedThread<Value: Sendable>(


### PR DESCRIPTION
## Summary

- serialize permission-stream termination with timer installation
- create the timer unscheduled, then publish it to the main run loop only if installation wins the shared lock
- add a deterministic regression that cancels while startup is paused immediately before installation

## Root cause

AXorcist #46 removed a synchronous main-queue join and correctly skipped starts that observed prior termination. A cancellation could still race between the start guard and `Timer.scheduledTimer`, allowing a terminated stream to create a timer after cancellation had won.

The shared state now establishes one order: termination-first refuses installation, while installation-first leaves the exact timer available for the existing asynchronous main-actor invalidation.

## Proof

- `swift test --filter PermissionChangeStreamTests` — 3 tests passed
- `swift test` — 166 AXorcist tests and 1 command-conversion test passed
- scoped SwiftFormat lint — clean
- scoped strict SwiftLint — 0 violations
- final P0–P2 structured review — clean at confidence 0.96

Follow-up to #46.
