### PR TITLE
fix: bound synchronous observer lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add immutable per-request accessibility traversal options while keeping the legacy process defaults source-compatible and thread-safe.
 
 ### Fixed
+- Route synchronous and legacy element observation through the shared bounded registration and cleanup state machine, so a wedged Accessibility endpoint cannot block the main actor indefinitely or escape late-result rollback.
 - Bound asynchronous AX notification add and remove waits, including removal joins and subscription setup retries, so a wedged Accessibility endpoint cannot hang global observer startup or teardown. Thanks @SebTardif.
 - Refuse per-element Accessibility reads when macOS cannot arm their messaging deadline, and report any failure to clear an armed deadline after the protected operation.
 - Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications` and application readiness, keep observer creation, registration, and cleanup deadline-bounded off the main actor so a wedged app cannot block startup or teardown, retain semantic application identity across wrapper churn, reset shared observers with unprivileged process-unique identities across PID reuse, recover boundedly from transient registration failures, and reject the invalid PID-zero observer path.

--- a/Sources/AXorcist/Core/AXObserverCenter+PendingNative.swift
+++ b/Sources/AXorcist/Core/AXObserverCenter+PendingNative.swift
@@ -3,25 +3,55 @@ import Foundation
 
 @MainActor
 extension AXObserverCenter {
-    func subscribeNativeSetupError(
+    func setupRegistrationSynchronously(
         _ registration: AXObserverRegistrationKey,
         expectedGeneration: UInt64,
-        joined: AXError?,
-        hasNativeRegistration: Bool) -> AXError
+        expectedEpoch: ObserverStateEpoch) -> Result<Void, AXObserverSubscriptionError>
     {
-        if let joined {
-            return joined
+        if self.nativeRegistrationStates[registration]?.processGeneration == expectedGeneration {
+            return .success(())
         }
-        if hasNativeRegistration {
-            return .success
+        if self.observerSetupOverride != nil {
+            let error = self.setupOverriddenObserver(registration, expectedGeneration: expectedGeneration)
+            return error == .success
+                ? .success(())
+                : .failure(.nativeRegistrationFailed(
+                    registration.subscription.pid,
+                    registration.subscription.notification,
+                    error))
         }
-        guard ObserverNativeWork.canLaunchNativeAdd(
-            hasPendingAdd: self.pendingRegistrations[registration] != nil,
-            hasUnconfirmedRemoval: self.pendingRemovals[registration] != nil)
-        else {
-            return .cannotComplete
+        guard self.pendingRemovals[registration] == nil else {
+            return .failure(.nativeRegistrationFailed(
+                registration.subscription.pid,
+                registration.subscription.notification,
+                .cannotComplete))
         }
-        return self.setupUnderlyingObserver(registration, expectedGeneration: expectedGeneration)
+        var waiterAlreadyParked = false
+        if self.pendingRegistrations[registration] == nil {
+            guard let observer = self.getOrCreateObserver(
+                for: registration.subscription.pid,
+                expectedGeneration: expectedGeneration)
+            else {
+                return .failure(.observerCreationFailed(registration.subscription.pid))
+            }
+            _ = self.launchPendingRegistration(
+                registration,
+                expectedGeneration: expectedGeneration,
+                observer: observer,
+                parkSynchronousWaiter: true)
+            waiterAlreadyParked = true
+        }
+        let error = self.finishPendingRegistrationSynchronously(
+            registration,
+            expectedGeneration: expectedGeneration,
+            expectedEpoch: expectedEpoch,
+            waiterAlreadyParked: waiterAlreadyParked) ?? .cannotComplete
+        return error == .success
+            ? .success(())
+            : .failure(.nativeRegistrationFailed(
+                registration.subscription.pid,
+                registration.subscription.notification,
+                error))
     }
 
     func setupRegistrationAsync(
@@ -38,48 +68,185 @@ extension AXObserverCenter {
             _ = await pending.completion.value()
             if let stored = pending.completion.currentResult() {
                 return NativeRegistrationSetupResult(
-                    error: stored,
+                    error: stored.error,
                     state: self.nativeRegistrationStates[registration])
             }
             return NativeRegistrationSetupResult(error: .cannotComplete, state: nil)
         }
-        let id = UUID()
-        let completion = NativeRemovalCompletion()
-        let task = Task { @MainActor in
-            let error = await self.setupUnderlyingObserverAsync(
-                registration,
-                operationID: id,
-                expectedGeneration: expectedGeneration)
-            if let stored = completion.currentResult() {
-                return NativeRegistrationSetupResult(
-                    error: stored,
-                    state: self.nativeRegistrationStates[registration])
-            }
-            return NativeRegistrationSetupResult(error: error, state: nil)
+        guard let observer = await self.getOrCreateObserverAsync(
+            for: registration.subscription.pid,
+            expectedGeneration: expectedGeneration)
+        else {
+            return NativeRegistrationSetupResult(error: .failure, state: nil)
         }
-        self.pendingRegistrations[registration] = PendingRegistration(
-            id: id,
+        let pending = self.launchPendingRegistration(
+            registration,
+            expectedGeneration: expectedGeneration,
+            observer: observer,
+            parkSynchronousWaiter: false)
+        return await pending.task.value
+    }
+
+    private func launchPendingRegistration(
+        _ registration: AXObserverRegistrationKey,
+        expectedGeneration: UInt64,
+        observer: AXObserver,
+        parkSynchronousWaiter: Bool) -> PendingRegistration
+    {
+        if let pending = self.pendingRegistrations[registration] {
+            return pending
+        }
+        let launch = PendingAddLaunch(
+            id: UUID(),
+            expectedGeneration: expectedGeneration,
+            completion: NativeAddCompletion(),
+            work: self.nativeRegistrationWork(for: registration, observer: observer),
+            startGate: ObserverAsyncStartGate())
+        let task = self.makePendingRegistrationTask(registration, launch: launch)
+        let pending = PendingRegistration(
+            id: launch.id,
             expectedGeneration: expectedGeneration,
             task: task,
-            completion: completion)
-        return await task.value
+            completion: launch.completion,
+            work: launch.work)
+        self.pendingRegistrations[registration] = pending
+        if parkSynchronousWaiter {
+            _ = launch.completion.beginSynchronousWait()
+        }
+        launch.startGate.open()
+        return pending
+    }
+
+    private func makePendingRegistrationTask(
+        _ registration: AXObserverRegistrationKey,
+        launch: PendingAddLaunch) -> Task<NativeRegistrationSetupResult, Never>
+    {
+        let nativeWorkAdmission = self.nativeWorkAdmission
+        return Task.detached(priority: .utility) { [weak self] in
+            await launch.startGate.wait()
+            guard let self else {
+                return NativeRegistrationSetupResult(error: .cannotComplete, state: nil)
+            }
+            let first = await ObserverNativeWork.runPendingAdd(
+                admission: nativeWorkAdmission,
+                operation: launch.work.add)
+            { [weak self] nativeError in
+                let outcome = ObserverNativeWork.PendingNativeFirstResult(
+                    error: nativeError,
+                    timedOut: true)
+                if launch.completion.finishNative(with: outcome) == .asynchronous {
+                    Task.detached(priority: .utility) { [weak self] in
+                        let finalGeneration = await ObserverNativeWork.boundedProcessUniqueIdentity(
+                            registration.subscription.pid,
+                            admission: nativeWorkAdmission)
+                        await self?.resolveLaunchedPendingAdd(
+                            registration,
+                            launch: launch,
+                            outcome: outcome,
+                            finalGeneration: finalGeneration)
+                    }
+                }
+            }
+            if !first.timedOut {
+                if launch.completion.finishNative(with: first) == .asynchronous {
+                    let finalGeneration = await ObserverNativeWork.boundedProcessUniqueIdentity(
+                        registration.subscription.pid,
+                        admission: nativeWorkAdmission)
+                    await self.resolveLaunchedPendingAdd(
+                        registration,
+                        launch: launch,
+                        outcome: first,
+                        finalGeneration: finalGeneration)
+                }
+            }
+            return await self.registrationSetupResult(
+                registration,
+                expectedGeneration: launch.expectedGeneration,
+                completion: launch.completion,
+                fallbackError: first.error)
+        }
+    }
+
+    func registrationSetupResult(
+        _ registration: AXObserverRegistrationKey,
+        expectedGeneration: UInt64,
+        completion: NativeAddCompletion,
+        fallbackError: AXError) -> NativeRegistrationSetupResult
+    {
+        if let resolved = completion.currentResult(), resolved.error != .success {
+            return NativeRegistrationSetupResult(error: resolved.error, state: nil)
+        }
+        if let state = self.nativeRegistrationStates[registration],
+           state.processGeneration == expectedGeneration,
+           self.pendingRemovals[registration] == nil
+        {
+            return NativeRegistrationSetupResult(error: .success, state: state)
+        }
+        if let resolved = completion.currentResult() {
+            return NativeRegistrationSetupResult(
+                error: resolved.error == .success ? .cannotComplete : resolved.error,
+                state: nil)
+        }
+        return NativeRegistrationSetupResult(error: fallbackError, state: nil)
+    }
+
+    private func resolveLaunchedPendingAdd(
+        _ registration: AXObserverRegistrationKey,
+        launch: PendingAddLaunch,
+        outcome: ObserverNativeWork.PendingNativeFirstResult,
+        finalGeneration: UInt64?)
+    {
+        guard launch.completion.beginAsynchronousResolution() else { return }
+        self.completePendingAdd(
+            registration,
+            resolution: PendingAddResolution(
+                operationID: launch.id,
+                expectedGeneration: launch.expectedGeneration,
+                cleanup: launch.work,
+                outcome: outcome,
+                finalGeneration: finalGeneration,
+                hasSynchronousWaiter: false))
+        let resolved = self.resolvedPendingAddOutcome(
+            registration,
+            operationID: launch.id,
+            expectedGeneration: launch.expectedGeneration,
+            nativeOutcome: outcome)
+        launch.completion.publishResolved(resolved)
     }
 
     func finishPendingRegistrationSynchronously(
         _ registration: AXObserverRegistrationKey,
         expectedGeneration: UInt64,
-        expectedEpoch: ObserverStateEpoch) -> AXError?
+        expectedEpoch: ObserverStateEpoch,
+        waiterAlreadyParked: Bool = false) -> AXError?
     {
         guard let pending = self.pendingRegistrations[registration] else { return nil }
         guard pending.expectedGeneration == expectedGeneration else { return .cannotComplete }
-        pending.completion.parkWaiter()
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(2))
-        while pending.completion.currentResult() == nil, clock.now < deadline {
-            _ = RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.01))
+        let ownsResolution = waiterAlreadyParked || pending.completion.beginSynchronousWait()
+        guard ownsResolution else {
+            return pending.completion.currentResult()?.error ?? .cannotComplete
         }
-        pending.completion.unparkWaiter()
-        guard let error = pending.completion.currentResult() else { return .cannotComplete }
+        let clock = ContinuousClock()
+        guard let nativeOutcome = pending.completion.waitForNativeResult(
+            until: clock.now.advanced(by: .seconds(2)))
+        else {
+            return .cannotComplete
+        }
+        self.completePendingAdd(
+            registration,
+            resolution: PendingAddResolution(
+                operationID: pending.id,
+                expectedGeneration: expectedGeneration,
+                cleanup: pending.work,
+                outcome: nativeOutcome,
+                finalGeneration: self.processIdentityProvider(registration.subscription.pid),
+                hasSynchronousWaiter: true))
+        let outcome = self.resolvedPendingAddOutcome(
+            registration,
+            operationID: pending.id,
+            expectedGeneration: expectedGeneration,
+            nativeOutcome: nativeOutcome)
+        pending.completion.publishResolved(outcome)
         let expectedState = NativeRegistrationState(
             operationID: pending.id,
             processGeneration: expectedGeneration)
@@ -87,131 +254,101 @@ extension AXObserverCenter {
         guard self.currentStateEpoch(for: registration.subscription.pid) == expectedEpoch else {
             return .cannotComplete
         }
-        if error == .success {
+        if outcome.error == .success {
             guard self.observerGenerations[registration.subscription.pid]?.startIdentity == expectedGeneration else {
                 return .cannotComplete
             }
-            guard alreadyCommitted else { return nil }
+            guard alreadyCommitted else { return .cannotComplete }
         }
-        if error != .success {
-            self.removeObserverIfUnused(targetPid: registration.subscription.pid)
-        }
-        return error
+        return outcome.error
     }
 
-    func setupUnderlyingObserverAsync(
+    private func resolvedPendingAddOutcome(
         _ registration: AXObserverRegistrationKey,
         operationID: UUID,
-        expectedGeneration: UInt64) async -> AXError
+        expectedGeneration: UInt64,
+        nativeOutcome: ObserverNativeWork.PendingNativeFirstResult) -> ObserverNativeWork.PendingNativeFirstResult
     {
-        let targetPid = registration.subscription.pid
-        guard let observer = await self.getOrCreateObserverAsync(
-            for: targetPid,
-            expectedGeneration: expectedGeneration)
-        else {
-            self.finishOwnedPendingAdd(
-                registration,
-                operationID: operationID,
-                error: .failure)
-            return .failure
+        guard nativeOutcome.error == .success else { return nativeOutcome }
+        let expectedState = NativeRegistrationState(
+            operationID: operationID,
+            processGeneration: expectedGeneration)
+        guard self.nativeRegistrationStates[registration] == expectedState else {
+            return ObserverNativeWork.PendingNativeFirstResult(
+                error: .cannotComplete,
+                timedOut: nativeOutcome.timedOut)
         }
-        let registrationWork = self.nativeNotificationRegistration(for: registration, observer: observer)
-        let nativeWorkAdmission = self.nativeWorkAdmission
-        let first = await ObserverNativeWork.runPendingAdd(
-            admission: nativeWorkAdmission,
-            operation: registrationWork.add)
-        { nativeError in
-            Task { @MainActor in
-                await self.completePendingAdd(
-                    registration,
-                    operationID: operationID,
-                    expectedGeneration: expectedGeneration,
-                    cleanup: registrationWork,
-                    outcome: ObserverNativeWork.PendingNativeFirstResult(
-                        error: nativeError,
-                        timedOut: true))
-            }
-        }
-        if !first.timedOut {
-            await self.completePendingAdd(
-                registration,
-                operationID: operationID,
-                expectedGeneration: expectedGeneration,
-                cleanup: registrationWork,
-                outcome: first)
-        }
-        return first.error
+        return nativeOutcome
     }
 
     func completePendingAdd(
         _ registration: AXObserverRegistrationKey,
-        operationID: UUID,
-        expectedGeneration: UInt64,
-        cleanup: NativeNotificationRegistration,
-        outcome: ObserverNativeWork.PendingNativeFirstResult) async
+        resolution: PendingAddResolution)
     {
-        let finalGeneration = await ObserverNativeWork.boundedProcessUniqueIdentity(
-            registration.subscription.pid,
-            admission: self.nativeWorkAdmission)
+        let expectedState = NativeRegistrationState(
+            operationID: resolution.operationID,
+            processGeneration: resolution.expectedGeneration)
+        if self.nativeRegistrationStates[registration] == expectedState {
+            return
+        }
         let pending = self.pendingRegistrations[registration]
-        let stillPending = pending?.id == operationID
-        let waiterCount = stillPending ? (pending?.completion.waiterCount ?? 0) : 0
-        let generationMatches = finalGeneration == expectedGeneration
+        let stillPending = pending?.id == resolution.operationID
+        let waiterCount = stillPending
+            ? (pending?.completion.resolutionWaiterCount ?? 0) + (resolution.hasSynchronousWaiter ? 1 : 0)
+            : 0
+        let generationMatches = resolution.finalGeneration == resolution.expectedGeneration
         let disposition = ObserverNativeWork.pendingAddDisposition(
-            nativeError: outcome.error,
+            nativeError: resolution.outcome.error,
             stillPending: stillPending,
             waiterCount: waiterCount,
             generationMatches: generationMatches,
-            isLate: outcome.timedOut)
+            isLate: resolution.outcome.timedOut)
 
         self.logObserverAddResult(
             targetPid: registration.subscription.pid,
             notification: registration.subscription.notification,
-            error: outcome.error)
+            error: resolution.outcome.error)
 
         switch disposition {
         case .commit:
             self.nativeRegistrationStates[registration] = NativeRegistrationState(
-                operationID: operationID,
-                processGeneration: expectedGeneration)
+                operationID: resolution.operationID,
+                processGeneration: resolution.expectedGeneration)
             if stillPending {
-                pending?.completion.finish(with: .success)
                 self.pendingRegistrations.removeValue(forKey: registration)
             }
         case .pendingRemoval:
-            if stillPending {
-                pending?.completion.finish(with: .cannotComplete)
-                self.pendingRegistrations.removeValue(forKey: registration)
-            }
-            if ObserverNativeWork.shouldResetObserverGeneration(
-                observed: finalGeneration,
-                expected: expectedGeneration)
-            {
-                self.resetObserverGeneration(
-                    for: registration.subscription.pid,
-                    ifMatching: expectedGeneration)
-            }
-            if stillPending || self.shouldScheduleUnownedLateRemoval(registration) {
-                self.scheduleNativeRemoval(registration, cleanup: cleanup)
-            }
+            self.completePendingAddRemoval(
+                registration,
+                resolution: resolution,
+                stillPending: stillPending)
         case .finishOnly:
             if stillPending {
-                pending?.completion.finish(with: outcome.error)
                 self.pendingRegistrations.removeValue(forKey: registration)
             }
             self.removeObserverIfUnused(targetPid: registration.subscription.pid)
         }
     }
 
-    func finishOwnedPendingAdd(
+    private func completePendingAddRemoval(
         _ registration: AXObserverRegistrationKey,
-        operationID: UUID,
-        error: AXError)
+        resolution: PendingAddResolution,
+        stillPending: Bool)
     {
-        guard self.pendingRegistrations[registration]?.id == operationID else { return }
-        let pending = self.pendingRegistrations.removeValue(forKey: registration)
-        pending?.completion.finish(with: error)
-        self.removeObserverIfUnused(targetPid: registration.subscription.pid)
+        if stillPending {
+            self.pendingRegistrations.removeValue(forKey: registration)
+        }
+        if ObserverNativeWork.shouldResetObserverGeneration(
+            observed: resolution.finalGeneration,
+            expected: resolution.expectedGeneration)
+        {
+            self.resetObserverGeneration(
+                for: registration.subscription.pid,
+                ifMatching: resolution.expectedGeneration)
+        }
+        if stillPending || self.shouldScheduleUnownedLateRemoval(registration) {
+            self.scheduleNativeRemoval(registration, cleanup: resolution.cleanup)
+        }
     }
 
     func shouldScheduleUnownedLateRemoval(_ registration: AXObserverRegistrationKey) -> Bool {
@@ -222,7 +359,7 @@ extension AXObserverCenter {
 
     func scheduleNativeRemoval(
         _ registration: AXObserverRegistrationKey,
-        cleanup: NativeNotificationRegistration)
+        cleanup: ObserverNativeRegistrationWork)
     {
         let id = UUID()
         let completion = NativeRemovalCompletion()

--- a/Sources/AXorcist/Core/AXObserverCenter.swift
+++ b/Sources/AXorcist/Core/AXObserverCenter.swift
@@ -31,6 +31,9 @@ public final class AXObserverCenter {
         _ element: Element,
         _ notification: AXNotification) -> Void
     typealias ProcessIdentityProvider = @MainActor (_ pid: pid_t) -> UInt64?
+    typealias NativeRegistrationWorkProvider = @MainActor (
+        _ registration: AXObserverRegistrationKey,
+        _ observer: AXObserver) -> ObserverNativeRegistrationWork
 
     struct ObserverGeneration {
         let startIdentity: UInt64
@@ -40,7 +43,25 @@ public final class AXObserverCenter {
         let id: UUID
         let expectedGeneration: UInt64
         let task: Task<NativeRegistrationSetupResult, Never>
-        let completion: NativeRemovalCompletion
+        let completion: NativeAddCompletion
+        let work: ObserverNativeRegistrationWork
+    }
+
+    struct PendingAddLaunch {
+        let id: UUID
+        let expectedGeneration: UInt64
+        let completion: NativeAddCompletion
+        let work: ObserverNativeRegistrationWork
+        let startGate: ObserverAsyncStartGate
+    }
+
+    struct PendingAddResolution {
+        let operationID: UUID
+        let expectedGeneration: UInt64
+        let cleanup: ObserverNativeRegistrationWork
+        let outcome: ObserverNativeWork.PendingNativeFirstResult
+        let finalGeneration: UInt64?
+        let hasSynchronousWaiter: Bool
     }
 
     struct NativeRegistrationState: Equatable {
@@ -56,7 +77,7 @@ public final class AXObserverCenter {
     struct PendingRemoval {
         let id: UUID
         let completion: NativeRemovalCompletion
-        let cleanup: NativeNotificationRegistration
+        let cleanup: ObserverNativeRegistrationWork
     }
 
     struct ObserverWorkerKey: Hashable {
@@ -95,12 +116,12 @@ public final class AXObserverCenter {
     var pendingRegistrations: [AXObserverRegistrationKey: PendingRegistration] = [:]
     var pendingRemovals: [AXObserverRegistrationKey: PendingRemoval] = [:]
     var nativeRegistrationStates: [AXObserverRegistrationKey: NativeRegistrationState] = [:]
-    var asynchronousNativeRegistrations: Set<AXObserverRegistrationKey> = []
     var globalStateEpoch: UInt64 = 0
     var processStateEpochs: [pid_t: UInt64] = [:]
     let observerSetupOverride: ObserverSetup?
     let observerCleanupOverride: ObserverCleanup?
     let processIdentityProvider: ProcessIdentityProvider
+    let nativeRegistrationWorkProvider: NativeRegistrationWorkProvider?
 
     // MARK: - Lifecycle
 
@@ -108,6 +129,7 @@ public final class AXObserverCenter {
         self.observerSetupOverride = nil
         self.observerCleanupOverride = nil
         self.processIdentityProvider = Self.nativeProcessUniqueIdentity
+        self.nativeRegistrationWorkProvider = nil
     }
 
     init(
@@ -117,6 +139,7 @@ public final class AXObserverCenter {
         self.observerSetupOverride = observerSetup
         self.observerCleanupOverride = observerCleanup
         self.processIdentityProvider = { UInt64(UInt32(bitPattern: $0)) }
+        self.nativeRegistrationWorkProvider = nil
     }
 
     init(
@@ -127,6 +150,17 @@ public final class AXObserverCenter {
         self.observerSetupOverride = observerSetup
         self.observerCleanupOverride = observerCleanup
         self.processIdentityProvider = processIdentityProvider
+        self.nativeRegistrationWorkProvider = nil
+    }
+
+    init(
+        processIdentityProvider: @escaping ProcessIdentityProvider,
+        nativeRegistrationWorkProvider: @escaping NativeRegistrationWorkProvider)
+    {
+        self.observerSetupOverride = nil
+        self.observerCleanupOverride = nil
+        self.processIdentityProvider = processIdentityProvider
+        self.nativeRegistrationWorkProvider = nativeRegistrationWorkProvider
     }
 }
 
@@ -159,56 +193,73 @@ extension AXObserverCenter {
         notification: AXNotification,
         handler: @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
     {
+        self.subscribeStored(
+            pid: pid,
+            element: element,
+            notification: notification,
+            storedHandler: .standard(handler))
+            .mapError { $0.accessibilityError }
+    }
+
+    func subscribeObserverAware(
+        pid: pid_t,
+        element: Element,
+        notification: AXNotification,
+        handler: @escaping AXObserverAwareNotificationHandler) -> Result<SubscriptionToken, AXObserverSubscriptionError>
+    {
+        self.subscribeStored(
+            pid: pid,
+            element: element,
+            notification: notification,
+            storedHandler: .observerAware(handler))
+    }
+
+    private func subscribeStored(
+        pid: pid_t,
+        element: Element?,
+        notification: AXNotification,
+        storedHandler: AXStoredNotificationHandler) -> Result<SubscriptionToken, AXObserverSubscriptionError>
+    {
         guard pid > 0 else {
-            return .failure(.observerSetupFailed(
-                details: "macOS AXObserver requires an application PID greater than zero"))
+            return .failure(.validation(
+                "macOS AXObserver requires an application PID greater than zero"))
         }
         guard let expectedGeneration = self.processIdentityProvider(pid) else {
-            return .failure(.observerSetupFailed(
-                details: "Could not resolve the process generation for PID \(pid)"))
+            return .failure(.validation(
+                "Could not resolve the process generation for PID \(pid)"))
         }
         self.prepareObserverGeneration(for: pid, currentIdentity: expectedGeneration)
 
         let registration = self.registrationKey(pid: pid, element: element, notification: notification)
         let awaitedRemoval = self.finishPendingRemovalSynchronously(registration)
         guard awaitedRemoval != false else {
-            return .failure(.observerSetupFailed(
-                details: "Timed out awaiting observer cleanup for PID \(pid)"))
+            return .failure(.validation(
+                "Timed out awaiting observer cleanup for PID \(pid)"))
         }
         guard awaitedRemoval != true || self.processIdentityProvider(pid) == expectedGeneration else {
             self.resetObserverGeneration(for: pid, ifMatching: expectedGeneration)
-            return .failure(.observerSetupFailed(
-                details: "Process generation changed while awaiting observer cleanup for PID \(pid)"))
+            return .failure(.validation(
+                "Process generation changed while awaiting observer cleanup for PID \(pid)"))
         }
-        let expectedEpoch = self.currentStateEpoch(for: pid)
-        let joinedRegistration = self.finishPendingRegistrationSynchronously(
+        let setupResult = self.setupRegistrationSynchronously(
             registration,
             expectedGeneration: expectedGeneration,
-            expectedEpoch: expectedEpoch)
-        let hasNativeRegistration = self.nativeRegistrationStates[registration]?.processGeneration == expectedGeneration
-        let setupError = self.subscribeNativeSetupError(
-            registration,
-            expectedGeneration: expectedGeneration,
-            joined: joinedRegistration,
-            hasNativeRegistration: hasNativeRegistration)
-        guard setupError == .success else {
-            let errorMessage = "Failed to setup underlying AXObserver for \(describePid(pid)) " +
-                "notification \(notification.rawValue) (AXError \(setupError.rawValue))"
-            axErrorLog(errorMessage)
-            return .failure(.observerSetupFailed(details: errorMessage))
+            expectedEpoch: self.currentStateEpoch(for: pid))
+        if case let .failure(error) = setupResult {
+            axErrorLog(error.accessibilityError.localizedDescription)
+            return .failure(error)
         }
-        if joinedRegistration == nil, !hasNativeRegistration {
+        if self.observerSetupOverride != nil {
             self.nativeRegistrationStates[registration] = NativeRegistrationState(
                 operationID: UUID(),
                 processGeneration: expectedGeneration)
         }
-        if joinedRegistration != nil {
-            self.asynchronousNativeRegistrations.insert(registration)
-        } else if !hasNativeRegistration {
-            self.asynchronousNativeRegistrations.remove(registration)
+        guard self.nativeRegistrationStates[registration]?.processGeneration == expectedGeneration else {
+            return .failure(.validation(
+                "Observer registration completed without owned native state for PID \(pid)"))
         }
 
-        return .success(self.subscriptionStore.add(registration: registration, handler: handler))
+        return .success(self.subscriptionStore.add(registration: registration, handler: storedHandler))
     }
 
     func subscribeProcessAsync(
@@ -293,8 +344,9 @@ extension AXObserverCenter {
                 error: setupResult.error)
         }
         guard let state = setupResult.state, self.nativeRegistrationStates[registration] == state else { return nil }
-        self.asynchronousNativeRegistrations.insert(registration)
-        return .success(self.subscriptionStore.add(registration: registration, handler: handler))
+        return .success(self.subscriptionStore.add(
+            registration: registration,
+            handler: .standard(handler)))
     }
 
     private func asyncSetupFailure(
@@ -331,6 +383,52 @@ extension AXObserverCenter {
         self.cleanupUnderlyingObserverNotification(removal.registration)
     }
 
+    func unsubscribeCompatibility(token: SubscriptionToken) -> AXError {
+        guard let registration = self.subscriptionStore.registration(for: token) else {
+            return .notificationNotRegistered
+        }
+        if self.subscriptionStore.handlerCount(for: registration) > 1 || self.observerCleanupOverride != nil {
+            do {
+                try self.unsubscribe(token: token)
+                return .success
+            } catch {
+                return .notificationNotRegistered
+            }
+        }
+
+        if self.nativeRegistrationStates[registration] != nil,
+           self.pendingRemovals[registration] == nil
+        {
+            guard let observer = self.getObserver(for: registration.subscription.pid) else {
+                self.nativeRegistrationStates.removeValue(forKey: registration)
+                return self.removeCompatibilityToken(token, registration: registration)
+            }
+            self.scheduleNativeRemoval(
+                registration,
+                cleanup: self.nativeRegistrationWork(for: registration, observer: observer))
+        }
+        if self.pendingRemovals[registration] != nil,
+           self.finishPendingRemovalSynchronously(registration) != true
+        {
+            return self.pendingRemovals[registration]?.completion.currentResult() ?? .cannotComplete
+        }
+        guard self.nativeRegistrationStates[registration] == nil,
+              self.pendingRemovals[registration] == nil
+        else { return .cannotComplete }
+        return self.removeCompatibilityToken(token, registration: registration)
+    }
+
+    private func removeCompatibilityToken(
+        _ token: SubscriptionToken,
+        registration: AXObserverRegistrationKey) -> AXError
+    {
+        guard (try? self.subscriptionStore.remove(token: token)) != nil else {
+            return .notificationNotRegistered
+        }
+        self.removeObserverIfUnused(targetPid: registration.subscription.pid)
+        return .success
+    }
+
     public func removeAllObservers() {
         axInfoLog("Removing all observers and subscriptions globally.")
         self.advanceStateEpoch()
@@ -344,7 +442,6 @@ extension AXObserverCenter {
         self.pendingRegistrations.removeAll()
         self.pendingRemovals.removeAll()
         self.nativeRegistrationStates.removeAll()
-        self.asynchronousNativeRegistrations.removeAll()
         self.processStateEpochs.removeAll()
         self.subscriptionStore.removeAll()
 
@@ -408,61 +505,22 @@ extension AXObserverCenter {
         return observedElement == applicationElement ? .process : .element
     }
 
-    func setupUnderlyingObserver(
+    func setupOverriddenObserver(
         _ registration: AXObserverRegistrationKey,
         expectedGeneration: UInt64) -> AXError
     {
         let subscription = registration.subscription
-        if let observerSetupOverride {
-            let error = observerSetupOverride(subscription.pid, registration.element, subscription.notification)
-            let finalGeneration = self.processIdentityProvider(subscription.pid)
-            guard finalGeneration == expectedGeneration else {
-                if finalGeneration != nil {
-                    self.resetObserverGeneration(for: subscription.pid)
-                }
-                return .cannotComplete
-            }
-            if error == .success {
-                self.recordObserverGeneration(for: subscription.pid, startIdentity: expectedGeneration)
-            }
-            return error
-        }
-
-        let targetPid = subscription.pid
-        guard let observer = getOrCreateObserver(for: targetPid, expectedGeneration: expectedGeneration) else {
-            axErrorLog("Failed to get/create AXObserver for effective PID \(targetPid) during setup.")
-            return .failure
-        }
-
-        let registrationWork = self.nativeNotificationRegistration(for: registration, observer: observer)
-        let error = ObserverNativeWork.performSynchronously(
-            admission: self.nativeWorkAdmission,
-            refusalValue: AXError.cannotComplete)
-        {
-            registrationWork.add()
-        }
-
-        let finalGeneration = self.processIdentityProvider(targetPid)
+        guard let observerSetupOverride else { return .cannotComplete }
+        let error = observerSetupOverride(subscription.pid, registration.element, subscription.notification)
+        let finalGeneration = self.processIdentityProvider(subscription.pid)
         guard finalGeneration == expectedGeneration else {
-            if error == .success {
-                let removalError = ObserverNativeWork.tryPerformCleanupSynchronously(
-                    admission: self.nativeWorkAdmission,
-                    operation: { registrationWork.remove() })
-                if removalError == nil {
-                    self.scheduleNativeRemoval(registration, cleanup: registrationWork)
-                }
-            }
-            if finalGeneration == nil {
-                self.removeObserverIfUnused(targetPid: targetPid)
-            } else {
-                self.resetObserverGeneration(for: targetPid)
+            if finalGeneration != nil {
+                self.resetObserverGeneration(for: subscription.pid)
             }
             return .cannotComplete
         }
-
-        self.logObserverAddResult(targetPid: targetPid, notification: subscription.notification, error: error)
-        if error != .success {
-            self.removeObserverIfUnused(targetPid: targetPid)
+        if error == .success {
+            self.recordObserverGeneration(for: subscription.pid, startIdentity: expectedGeneration)
         }
         return error
     }
@@ -489,10 +547,13 @@ extension AXObserverCenter {
         return AXUIElement.application(pid: pid)
     }
 
-    func nativeNotificationRegistration(
+    func nativeRegistrationWork(
         for registration: AXObserverRegistrationKey,
-        observer: AXObserver) -> NativeNotificationRegistration
+        observer: AXObserver) -> ObserverNativeRegistrationWork
     {
+        if let nativeRegistrationWorkProvider {
+            return nativeRegistrationWorkProvider(registration, observer)
+        }
         let processScoped = registration.scope == .process
         let element = processScoped
             ? AXUIElement.application(pid: registration.subscription.pid)
@@ -502,7 +563,7 @@ extension AXObserverCenter {
             element: element,
             notification: registration.subscription.notification.rawValue as CFString,
             refcon: Unmanaged.passUnretained(self).toOpaque(),
-            appliesMessagingTimeout: processScoped)
+            appliesMessagingTimeout: processScoped).work
     }
 
     func logObserverAddResult(targetPid: pid_t, notification: AXNotification, error: AXError) {
@@ -522,7 +583,6 @@ extension AXObserverCenter {
         if let observerCleanupOverride {
             observerCleanupOverride(subscription.pid, registration.element, subscription.notification)
             self.nativeRegistrationStates.removeValue(forKey: registration)
-            self.asynchronousNativeRegistrations.remove(registration)
             return
         }
 
@@ -542,7 +602,6 @@ extension AXObserverCenter {
 
         guard let observer = getObserver(for: targetPid) else {
             self.nativeRegistrationStates.removeValue(forKey: registration)
-            self.asynchronousNativeRegistrations.remove(registration)
             axWarningLog(
                 logSegments(
                     "No AXObserver found for \(describePid(targetPid)) during cleanup",
@@ -554,29 +613,15 @@ extension AXObserverCenter {
             return
         }
 
-        let cleanup = self.nativeNotificationRegistration(for: registration, observer: observer)
-        guard self.asynchronousNativeRegistrations.contains(registration) else {
-            guard let error = ObserverNativeWork.tryPerformCleanupSynchronously(
-                admission: self.nativeWorkAdmission,
-                operation: {
-                    cleanup.remove()
-                })
-            else {
-                self.asynchronousNativeRegistrations.insert(registration)
-                self.scheduleNativeRemoval(registration, cleanup: cleanup)
-                return
-            }
-            self.finalizeNativeRemoval(registration, error: error)
-            return
-        }
-        self.scheduleNativeRemoval(registration, cleanup: cleanup)
+        self.scheduleNativeRemoval(
+            registration,
+            cleanup: self.nativeRegistrationWork(for: registration, observer: observer))
     }
 
     func finalizeNativeRemoval(_ registration: AXObserverRegistrationKey, error: AXError) {
         let targetPid = registration.subscription.pid
         let notification = registration.subscription.notification
         self.nativeRegistrationStates.removeValue(forKey: registration)
-        self.asynchronousNativeRegistrations.remove(registration)
         if NativeNotificationRegistration.removalConfirmsRegistrationAbsent(error) {
             axInfoLog(
                 logSegments(
@@ -653,7 +698,7 @@ extension AXObserverCenter {
         self.observers.first { $0.pid == pid }?.observer
     }
 
-    private func getOrCreateObserver(for pid: pid_t, expectedGeneration: UInt64) -> AXObserver? {
+    func getOrCreateObserver(for pid: pid_t, expectedGeneration: UInt64) -> AXObserver? {
         if let existing = getObserver(for: pid) {
             return existing
         }
@@ -866,40 +911,40 @@ extension AXObserverCenter {
     }
 
     private func makeObserverCallback() -> AXObserverCallbackWithInfo {
-        { _, element, notificationCFString, userInfo, refcon in
+        { observer, element, notificationCFString, userInfo, refcon in
             guard let refcon else { return }
             let center = Unmanaged<AXObserverCenter>.fromOpaque(refcon).takeUnretainedValue()
-            center.handleObserverCallback(
+            center.handleObserverCallback(event: AXObserverRawNotificationEvent(
+                observer: observer,
                 element: element,
-                notificationCFString: notificationCFString,
-                userInfo: userInfo)
+                notification: notificationCFString,
+                userInfo: userInfo))
         }
     }
 
-    private func handleObserverCallback(
-        element: AXUIElement,
-        notificationCFString: CFString,
-        userInfo: CFDictionary?)
-    {
+    private func handleObserverCallback(event: AXObserverRawNotificationEvent) {
         var elementPID: pid_t = 0
-        AXUIElementGetPid(element, &elementPID)
+        AXUIElementGetPid(event.element, &elementPID)
 
-        guard let axNotification = AXNotification(rawValue: notificationCFString as String) else {
+        guard let axNotification = AXNotification(rawValue: event.notification as String) else {
             axWarningLog(
                 logSegments(
-                    "Received unknown notification string: \(notificationCFString as String)",
+                    "Received unknown notification string: \(event.notification as String)",
                     "for \(describePid(elementPID))",
                     "Cannot call handler"))
             return
         }
 
-        let nsUserInfo = self.convertUserInfoDictionary(userInfo)
+        let nsUserInfo = self.convertUserInfoDictionary(event.userInfo)
         Task { @MainActor in
-            self.processNotification(
+            self.processNotification(AXObserverNotificationEvent(
+                observer: event.observer,
                 pid: elementPID,
                 notification: axNotification,
-                rawElement: element,
-                nsUserInfo: nsUserInfo)
+                notificationString: event.notification,
+                rawElement: event.element,
+                rawUserInfo: event.userInfo,
+                userInfo: nsUserInfo))
         }
     }
 
@@ -908,9 +953,6 @@ extension AXObserverCenter {
         self.observerGenerations.removeValue(forKey: pid)
         self.nativeRegistrationStates = self.nativeRegistrationStates.filter {
             $0.key.subscription.pid != pid
-        }
-        self.asynchronousNativeRegistrations = self.asynchronousNativeRegistrations.filter {
-            $0.subscription.pid != pid
         }
         axDebugLog("Removed AXObserver instance for effective PID \(pid).")
     }
@@ -921,17 +963,24 @@ extension AXObserverCenter {
 
     // MARK: - Main Notification Processing (Called by global callbacks)
 
+    func processNotification(_ event: AXObserverNotificationEvent) {
+        self.subscriptionStore.dispatch(event)
+    }
+
     func processNotification(
         pid: pid_t,
         notification: AXNotification,
         rawElement: AXUIElement,
         nsUserInfo: [String: Any]?)
     {
-        self.subscriptionStore.dispatch(
+        self.subscriptionStore.dispatch(AXObserverNotificationEvent(
+            observer: nil,
             pid: pid,
             notification: notification,
+            notificationString: notification.rawValue as CFString,
             rawElement: rawElement,
-            userInfo: nsUserInfo)
+            rawUserInfo: nil,
+            userInfo: nsUserInfo))
     }
 
     private func convertUserInfoDictionary(_ userInfo: CFDictionary?) -> [String: Any]? {

--- a/Sources/AXorcist/Core/ObserverNativeWork.swift
+++ b/Sources/AXorcist/Core/ObserverNativeWork.swift
@@ -211,25 +211,6 @@ nonisolated enum ObserverNativeWork {
         }
         onFinished(error)
     }
-
-    static func performSynchronously<Value>(
-        admission: ObserverNativeWorkerAdmission,
-        refusalValue: Value,
-        operation: () -> Value) -> Value
-    {
-        guard admission.tryAcquire() else { return refusalValue }
-        defer { admission.release() }
-        return operation()
-    }
-
-    static func tryPerformCleanupSynchronously<Value>(
-        admission: ObserverNativeWorkerAdmission,
-        operation: () -> Value) -> Value?
-    {
-        guard admission.tryAcquireCleanup() else { return nil }
-        defer { admission.release() }
-        return operation()
-    }
 }
 
 final nonisolated class ObserverNativeWorkerAdmission: @unchecked Sendable {
@@ -396,21 +377,61 @@ final nonisolated class FirstResultGate<Value: Sendable>: @unchecked Sendable {
     }
 }
 
-final nonisolated class NativeRemovalCompletion: @unchecked Sendable {
-    private struct RemovalWaiter {
+final nonisolated class ObserverAsyncStartGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var isOpen = false
+    private var waiter: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            let resumeNow = self.lock.withLock { () -> Bool in
+                if self.isOpen {
+                    return true
+                }
+                self.waiter = continuation
+                return false
+            }
+            if resumeNow {
+                continuation.resume()
+            }
+        }
+    }
+
+    func open() {
+        let waiter = self.lock.withLock { () -> CheckedContinuation<Void, Never>? in
+            self.isOpen = true
+            defer { self.waiter = nil }
+            return self.waiter
+        }
+        waiter?.resume()
+    }
+}
+
+nonisolated class NativeWorkCompletion<Value: Sendable>: @unchecked Sendable {
+    private struct Waiter {
         let id: UUID
-        let continuation: CheckedContinuation<AXError, Never>
+        let continuation: CheckedContinuation<Value, Never>
     }
 
     private let condition = NSCondition()
-    private var result: AXError?
-    private var waiters: [RemovalWaiter] = []
+    private let timeoutValue: Value
+    private var result: Value?
+    private var waiters: [Waiter] = []
     private var parkedWaiterCount = 0
+    private var finishedWaiterCount = 0
+    private var finishedSynchronousWaiterCount = 0
 
-    func parkWaiter() {
+    init(timeoutValue: Value) {
+        self.timeoutValue = timeoutValue
+    }
+
+    @discardableResult
+    func parkWaiter() -> Bool {
         self.condition.lock()
+        defer { self.condition.unlock() }
+        guard self.result == nil else { return false }
         self.parkedWaiterCount += 1
-        self.condition.unlock()
+        return true
     }
 
     func unparkWaiter() {
@@ -421,7 +442,7 @@ final nonisolated class NativeRemovalCompletion: @unchecked Sendable {
         self.condition.unlock()
     }
 
-    func wait(until deadline: ContinuousClock.Instant) -> AXError? {
+    func wait(until deadline: ContinuousClock.Instant) -> Value? {
         let clock = ContinuousClock()
         self.condition.lock()
         while self.result == nil, clock.now < deadline {
@@ -432,7 +453,7 @@ final nonisolated class NativeRemovalCompletion: @unchecked Sendable {
         return result
     }
 
-    func currentResult() -> AXError? {
+    func currentResult() -> Value? {
         self.condition.withLock { self.result }
     }
 
@@ -440,14 +461,24 @@ final nonisolated class NativeRemovalCompletion: @unchecked Sendable {
         self.condition.withLock { self.waiters.count + self.parkedWaiterCount }
     }
 
+    var waiterCountAtFinish: Int {
+        self.condition.withLock { self.finishedWaiterCount }
+    }
+
+    var synchronousWaiterCountAtFinish: Int {
+        self.condition.withLock { self.finishedSynchronousWaiterCount }
+    }
+
     @discardableResult
-    func finish(with result: AXError) -> Int {
+    func finish(with result: Value) -> Int {
         self.condition.lock()
         guard self.result == nil else {
             self.condition.unlock()
             return 0
         }
         self.result = result
+        self.finishedWaiterCount = self.waiters.count + self.parkedWaiterCount
+        self.finishedSynchronousWaiterCount = self.parkedWaiterCount
         let waiters = self.waiters
         self.waiters.removeAll()
         self.condition.broadcast()
@@ -458,7 +489,7 @@ final nonisolated class NativeRemovalCompletion: @unchecked Sendable {
         return waiters.count
     }
 
-    func value(timeout: Duration = .milliseconds(750)) async -> AXError {
+    func value(timeout: Duration = .milliseconds(750)) async -> Value {
         let waiterID = UUID()
         return await withCheckedContinuation { continuation in
             self.condition.lock()
@@ -467,7 +498,7 @@ final nonisolated class NativeRemovalCompletion: @unchecked Sendable {
                 continuation.resume(returning: result)
                 return
             }
-            self.waiters.append(RemovalWaiter(id: waiterID, continuation: continuation))
+            self.waiters.append(Waiter(id: waiterID, continuation: continuation))
             self.condition.unlock()
             Task.detached(priority: .utility) {
                 try? await Task.sleep(for: timeout)
@@ -486,7 +517,114 @@ final nonisolated class NativeRemovalCompletion: @unchecked Sendable {
         }
         let waiter = self.waiters.remove(at: index)
         self.condition.unlock()
-        waiter.continuation.resume(returning: .cannotComplete)
+        waiter.continuation.resume(returning: self.timeoutValue)
+    }
+}
+
+final nonisolated class NativeRemovalCompletion: NativeWorkCompletion<AXError>, @unchecked Sendable {
+    init() {
+        super.init(timeoutValue: .cannotComplete)
+    }
+}
+
+nonisolated enum NativeAddResolutionOwner: Equatable, Sendable {
+    case synchronous
+    case asynchronous
+    case alreadyFinished
+}
+
+final nonisolated class NativeAddCompletion: @unchecked Sendable {
+    private enum ResolutionState {
+        case waitingForNative
+        case queuedAsynchronous
+        case synchronous
+        case resolvingAsynchronously
+        case resolved
+    }
+
+    private let condition = NSCondition()
+    private let resolved = NativeWorkCompletion<ObserverNativeWork.PendingNativeFirstResult>(
+        timeoutValue: ObserverNativeWork.PendingNativeFirstResult(
+            error: .cannotComplete,
+            timedOut: true))
+    private var nativeResult: ObserverNativeWork.PendingNativeFirstResult?
+    private var synchronousWaiterActive = false
+    private var waiterCountWhenNativeFinished = 0
+    private var resolutionState = ResolutionState.waitingForNative
+
+    func beginSynchronousWait() -> Bool {
+        self.condition.lock()
+        defer { self.condition.unlock() }
+        switch self.resolutionState {
+        case .waitingForNative where !self.synchronousWaiterActive:
+            self.synchronousWaiterActive = true
+            return true
+        case .queuedAsynchronous:
+            self.resolutionState = .synchronous
+            self.synchronousWaiterActive = true
+            return true
+        case .waitingForNative, .synchronous, .resolvingAsynchronously, .resolved:
+            return false
+        }
+    }
+
+    func finishNative(with result: ObserverNativeWork.PendingNativeFirstResult) -> NativeAddResolutionOwner {
+        self.condition.lock()
+        guard self.nativeResult == nil else {
+            self.condition.unlock()
+            return .alreadyFinished
+        }
+        self.nativeResult = result
+        self.waiterCountWhenNativeFinished = self.resolved.waiterCount + (self.synchronousWaiterActive ? 1 : 0)
+        let owner: NativeAddResolutionOwner = self.synchronousWaiterActive ? .synchronous : .asynchronous
+        self.resolutionState = self.synchronousWaiterActive ? .synchronous : .queuedAsynchronous
+        self.condition.broadcast()
+        self.condition.unlock()
+        return owner
+    }
+
+    func waitForNativeResult(until deadline: ContinuousClock.Instant) -> ObserverNativeWork.PendingNativeFirstResult? {
+        let clock = ContinuousClock()
+        self.condition.lock()
+        while self.nativeResult == nil, clock.now < deadline {
+            self.condition.wait(until: Date(timeIntervalSinceNow: 0.01))
+        }
+        let result = self.nativeResult
+        self.synchronousWaiterActive = false
+        self.condition.unlock()
+        return result
+    }
+
+    func beginAsynchronousResolution() -> Bool {
+        self.condition.lock()
+        defer { self.condition.unlock() }
+        guard self.resolutionState == .queuedAsynchronous else { return false }
+        self.resolutionState = .resolvingAsynchronously
+        return true
+    }
+
+    func publishResolved(_ result: ObserverNativeWork.PendingNativeFirstResult) {
+        self.condition.withLock {
+            self.resolutionState = .resolved
+            self.synchronousWaiterActive = false
+        }
+        self.resolved.finish(with: result)
+    }
+
+    func currentResult() -> ObserverNativeWork.PendingNativeFirstResult? {
+        self.resolved.currentResult()
+    }
+
+    func value(timeout: Duration = .milliseconds(750)) async -> ObserverNativeWork.PendingNativeFirstResult {
+        await self.resolved.value(timeout: timeout)
+    }
+
+    var waiterCountAtNativeFinish: Int {
+        self.condition.withLock { self.waiterCountWhenNativeFinished }
+    }
+
+    var resolutionWaiterCount: Int {
+        self.resolved.waiterCount
     }
 }
 
@@ -581,4 +719,13 @@ nonisolated struct NativeNotificationRegistration: @unchecked Sendable {
         guard self.appliesMessagingTimeout else { return }
         AXUIElementSetMessagingTimeout(self.element, 0)
     }
+
+    var work: ObserverNativeRegistrationWork {
+        ObserverNativeRegistrationWork(add: self.add, remove: self.remove)
+    }
+}
+
+nonisolated struct ObserverNativeRegistrationWork: Sendable {
+    let add: @Sendable () -> AXError
+    let remove: @Sendable () -> AXError
 }

--- a/Sources/AXorcist/Core/ObserverTypes.swift
+++ b/Sources/AXorcist/Core/ObserverTypes.swift
@@ -15,6 +15,53 @@ public typealias AXNotificationSubscriptionHandler = @MainActor ( /* element: El
     _ rawElement: AXUIElement,
     _ nsUserInfo: [String: Any]?) -> Void
 
+typealias AXObserverAwareNotificationHandler = @MainActor (
+    _ observer: AXObserver,
+    _ rawElement: AXUIElement,
+    _ notification: CFString,
+    _ userInfo: CFDictionary?) -> Void
+
+enum AXStoredNotificationHandler {
+    case standard(AXNotificationSubscriptionHandler)
+    case observerAware(AXObserverAwareNotificationHandler)
+}
+
+enum AXObserverSubscriptionError: Error {
+    case observerCreationFailed(pid_t)
+    case nativeRegistrationFailed(pid_t, AXNotification, AXError)
+    case validation(String)
+
+    @MainActor var accessibilityError: AccessibilityError {
+        switch self {
+        case let .observerCreationFailed(pid):
+            .observerSetupFailed(details: "Could not create AXObserver for \(describePid(pid))")
+        case let .nativeRegistrationFailed(pid, notification, error):
+            .observerSetupFailed(
+                details: "Failed to setup underlying AXObserver for \(describePid(pid)) " +
+                    "notification \(notification.rawValue) (AXError \(error.rawValue))")
+        case let .validation(details):
+            .observerSetupFailed(details: details)
+        }
+    }
+}
+
+nonisolated struct AXObserverRawNotificationEvent: @unchecked Sendable {
+    let observer: AXObserver
+    let element: AXUIElement
+    let notification: CFString
+    let userInfo: CFDictionary?
+}
+
+nonisolated struct AXObserverNotificationEvent: @unchecked Sendable {
+    let observer: AXObserver?
+    let pid: pid_t
+    let notification: AXNotification
+    let notificationString: CFString
+    let rawElement: AXUIElement
+    let rawUserInfo: CFDictionary?
+    let userInfo: [String: Any]?
+}
+
 /// The single registration boundary used by AXorcist's observer APIs.
 @MainActor
 protocol AXObservationRegistry: AnyObject, Sendable {
@@ -130,7 +177,7 @@ final class AXObserverSubscriptionStore {
         let removedLastHandler: Bool
     }
 
-    private var subscriptions: [AXObserverRegistrationKey: [UUID: AXNotificationSubscriptionHandler]] = [:]
+    private var subscriptions: [AXObserverRegistrationKey: [UUID: AXStoredNotificationHandler]] = [:]
     private var subscriptionTokens: [UUID: AXObserverRegistrationKey] = [:]
 
     var registeredKeys: [AXNotificationSubscriptionKey] {
@@ -139,12 +186,19 @@ final class AXObserverSubscriptionStore {
 
     func add(
         registration: AXObserverRegistrationKey,
-        handler: @escaping AXNotificationSubscriptionHandler) -> SubscriptionToken
+        handler: AXStoredNotificationHandler) -> SubscriptionToken
     {
         let token = SubscriptionToken(id: UUID())
         self.subscriptions[registration, default: [:]][token.id] = handler
         self.subscriptionTokens[token.id] = registration
         return token
+    }
+
+    func add(
+        registration: AXObserverRegistrationKey,
+        handler: @escaping AXNotificationSubscriptionHandler) -> SubscriptionToken
+    {
+        self.add(registration: registration, handler: .standard(handler))
     }
 
     func remove(token: SubscriptionToken) throws -> Removal {
@@ -186,6 +240,14 @@ final class AXObserverSubscriptionStore {
         }
     }
 
+    func registration(for token: SubscriptionToken) -> AXObserverRegistrationKey? {
+        self.subscriptionTokens[token.id]
+    }
+
+    func handlerCount(for registration: AXObserverRegistrationKey) -> Int {
+        self.subscriptions[registration]?.count ?? 0
+    }
+
     func contains(pid: pid_t, notification: AXNotification) -> Bool {
         self.subscriptions.contains { registration, handlers in
             registration.subscription.pid == pid &&
@@ -204,17 +266,12 @@ final class AXObserverSubscriptionStore {
         }
     }
 
-    func dispatch(
-        pid: pid_t,
-        notification: AXNotification,
-        rawElement: AXUIElement,
-        userInfo: [String: Any]?)
-    {
+    func dispatch(_ event: AXObserverNotificationEvent) {
         let specificKey = AXNotificationSubscriptionKey(
-            pid: pid,
-            notification: notification)
-        var handlersToCall: [AXNotificationSubscriptionHandler] = []
-        let eventElement = Element(rawElement)
+            pid: event.pid,
+            notification: event.notification)
+        var handlersToCall: [AXStoredNotificationHandler] = []
+        let eventElement = Element(event.rawElement)
         for (registration, handlers) in self.subscriptions {
             let subscription = registration.subscription
             let matchesProcess = subscription == specificKey && registration.scope == .process
@@ -229,7 +286,29 @@ final class AXObserverSubscriptionStore {
         }
 
         for handler in handlersToCall {
-            handler(pid, notification, rawElement, userInfo)
+            switch handler {
+            case let .standard(standard):
+                standard(event.pid, event.notification, event.rawElement, event.userInfo)
+            case let .observerAware(observerAware):
+                guard let observer = event.observer else { continue }
+                observerAware(observer, event.rawElement, event.notificationString, event.rawUserInfo)
+            }
         }
+    }
+
+    func dispatch(
+        pid: pid_t,
+        notification: AXNotification,
+        rawElement: AXUIElement,
+        userInfo: [String: Any]?)
+    {
+        self.dispatch(AXObserverNotificationEvent(
+            observer: nil,
+            pid: pid,
+            notification: notification,
+            notificationString: notification.rawValue as CFString,
+            rawElement: rawElement,
+            rawUserInfo: nil,
+            userInfo: userInfo))
     }
 }

--- a/Sources/AXorcist/Utils/AXObserverManager.swift
+++ b/Sources/AXorcist/Utils/AXObserverManager.swift
@@ -4,271 +4,125 @@ import Foundation
 
 /// Manages accessibility observers for monitoring UI element changes.
 ///
-/// Legacy raw-callback observer API retained for source compatibility.
-///
-/// New code should use ``AXObserverCenter`` or ``NotificationWatcher``. AXorcist commands no longer
-/// use this separate compatibility manager, so observe and stop operations share one token registry.
-///
-/// ## Overview
-///
-/// The manager:
-/// - Creates and manages AXObserver instances for monitoring UI elements
-/// - Routes notifications to appropriate callbacks
-/// - Handles observer lifecycle and cleanup
-/// - Provides thread-safe observer management
-///
-/// This is a singleton class that should be accessed via ``shared``.
-///
-/// ## Topics
-///
-/// ### Getting the Shared Instance
-///
-/// - ``shared``
-///
-/// ### Managing Observers
-///
-/// - ``addObserver(for:notification:callback:)``
-/// - ``removeObserver(for:notification:)``
-/// - ``removeAllObservers(for:)``
-///
-/// ### Types
-///
-/// - ``AXNotificationCallback``
-/// - ``ObserverError``
+/// Legacy raw-callback observer API retained for source compatibility. New code should use
+/// ``AXObserverCenter`` or ``NotificationWatcher``. This adapter owns only its logical tokens;
+/// native observer creation, bounded registration, late-result cleanup, and removal all remain
+/// centralized in ``AXObserverCenter``.
 @MainActor
 @available(*, deprecated, message: "Use AXObserverCenter or NotificationWatcher for token-based observation")
-public class AXObserverManager {
+public final class AXObserverManager {
     // MARK: Lifecycle
 
-    private init() {}
+    private init() {
+        self.observationCenter = .shared
+    }
+
+    init(observationCenter: AXObserverCenter) {
+        self.observationCenter = observationCenter
+    }
 
     // MARK: Public
 
-    /// Typealias for notification callback - matches AXObserverCallbackWithInfo but without refcon
+    /// Typealias for notification callback - matches AXObserverCallbackWithInfo but without refcon.
     public typealias AXNotificationCallback = (AXObserver, AXUIElement, CFString, CFDictionary?) -> Void
 
-    /// Error types
+    /// Error types retained by the compatibility API.
     public enum ObserverError: Error {
         case couldNotCreateObserver
         case addNotificationFailed(AXError)
         case other(String)
     }
 
-    /// Singleton instance
+    /// Singleton instance.
     public static let shared = AXObserverManager()
 
-    /// Add observer for an element and notification
+    /// Add an observer for an element and notification.
     public func addObserver(
         for element: Element,
         notification: AXNotification,
         callback: @escaping AXNotificationCallback) throws
     {
-        let elementId = ObjectIdentifier(element.underlyingElement as AnyObject)
-
-        self.observerLock.lock()
-        defer { observerLock.unlock() }
-
-        if var observerInfo = observers[elementId] {
-            try updateExistingObserver(
-                info: &observerInfo,
-                element: element,
-                notification: notification,
-                callback: callback)
-            self.observers[elementId] = observerInfo
+        let key = RegistrationKey(element: element, notification: notification)
+        if let registration = self.registrations[key] {
+            registration.callback.callback = callback
             return
         }
 
-        self.observers[elementId] = try createObserverInfo(
-            for: element,
-            notification: notification,
-            callback: callback)
+        guard let pid = element.pid() else {
+            throw ObserverError.other("Could not get PID for element")
+        }
+        let callbackBox = CallbackBox(callback: callback)
+        let result = self.observationCenter.subscribeObserverAware(
+            pid: pid,
+            element: element,
+            notification: notification)
+        { observer, rawElement, notificationString, userInfo in
+            callbackBox.callback(observer, rawElement, notificationString, userInfo)
+        }
+        switch result {
+        case let .success(token):
+            self.registrations[key] = Registration(token: token, callback: callbackBox)
+        case let .failure(error):
+            throw self.compatibilityError(from: error)
+        }
     }
 
-    /// Remove observer for an element and notification
+    /// Remove the observer owned by this compatibility manager for an element and notification.
     public func removeObserver(for element: Element, notification: AXNotification) throws {
-        let elementId = ObjectIdentifier(element.underlyingElement as AnyObject)
-
-        self.observerLock.lock()
-        defer { observerLock.unlock() }
-
-        guard var observerInfo = observers[elementId] else {
-            // No observer for this element
-            return
-        }
-
-        // Remove the notification from the observer
-        let error = AXObserverRemoveNotification(
-            observerInfo.observer,
-            element.underlyingElement,
-            notification.rawValue as CFString)
-        if error != .success {
-            axErrorLog("Failed to remove notification: \(error)")
+        let key = RegistrationKey(element: element, notification: notification)
+        guard let registration = self.registrations[key] else { return }
+        let error = self.observationCenter.unsubscribeCompatibility(token: registration.token)
+        guard NativeNotificationRegistration.removalConfirmsRegistrationAbsent(error) else {
             throw ObserverError.other("Failed to remove notification: \(error)")
         }
-
-        // Remove the callback
-        observerInfo.callbacks.removeValue(forKey: notification.rawValue as CFString)
-
-        // If no more callbacks, remove the observer entirely
-        if observerInfo.callbacks.isEmpty {
-            // Remove from run loop
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), observerInfo.runLoopSource, .defaultMode)
-
-            // Invalidate the observer
-            CFRunLoopSourceInvalidate(observerInfo.runLoopSource)
-
-            // Remove from our storage
-            self.observers.removeValue(forKey: elementId)
-
-            axDebugLog("Removed observer for element")
-        } else {
-            // Update the observer info with removed callback
-            self.observers[elementId] = observerInfo
-        }
+        self.registrations.removeValue(forKey: key)
     }
 
-    /// Remove all observers
+    /// Remove every observer owned by this compatibility manager without affecting other clients.
     public func removeAllObservers() {
-        self.observerLock.lock()
-        defer { observerLock.unlock() }
-
-        for (_, observerInfo) in self.observers {
-            // Remove from run loop
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), observerInfo.runLoopSource, .defaultMode)
-
-            // Invalidate the observer
-            CFRunLoopSourceInvalidate(observerInfo.runLoopSource)
+        let registrations = Array(self.registrations.values)
+        self.registrations.removeAll()
+        for registration in registrations {
+            try? self.observationCenter.unsubscribe(token: registration.token)
         }
-
-        self.observers.removeAll()
-        axDebugLog("Removed all observers")
     }
 
     // MARK: Private
 
-    /// Private storage for observers and callbacks
-    private struct ObserverInfo {
-        let observer: AXObserver
-        let runLoopSource: CFRunLoopSource
-        var callbacks: [CFString: AXNotificationCallback] = [:]
-    }
+    private struct RegistrationKey: Hashable {
+        let elementID: ObjectIdentifier
+        let notification: AXNotification
 
-    private func notificationKey(for notification: AXNotification) -> CFString {
-        notification.rawValue as CFString
-    }
-
-    private var observers: [ObjectIdentifier: ObserverInfo] = [:]
-    private let observerLock = NSLock()
-
-    /// Handle incoming notifications
-    private func handleNotification(
-        observer: AXObserver,
-        element: AXUIElement,
-        notification: CFString,
-        userInfo: CFDictionary?)
-    {
-        let elementId = ObjectIdentifier(element as AnyObject)
-
-        self.observerLock.lock()
-        let observerInfo = self.observers[elementId]
-        self.observerLock.unlock()
-
-        guard let observerInfo,
-              let callback = observerInfo.callbacks[notification]
-        else {
-            axWarningLog("Received notification '\(notification)' but no callback found")
-            return
-        }
-
-        // Call the callback
-        callback(observer, element, notification, userInfo)
-    }
-}
-
-@MainActor
-@available(*, deprecated, message: "Use AXObserverCenter or NotificationWatcher for token-based observation")
-extension AXObserverManager {
-    private func updateExistingObserver(
-        info: inout ObserverInfo,
-        element: Element,
-        notification: AXNotification,
-        callback: @escaping AXNotificationCallback) throws
-    {
-        info.callbacks[self.notificationKey(for: notification)] = callback
-
-        let error = AXObserverAddNotification(
-            info.observer,
-            element.underlyingElement,
-            notification.rawValue as CFString,
-            nil)
-
-        if error != .success {
-            axErrorLog("Failed to add notification: \(error)")
-            throw ObserverError.addNotificationFailed(error)
+        init(element: Element, notification: AXNotification) {
+            self.elementID = ObjectIdentifier(element.underlyingElement as AnyObject)
+            self.notification = notification
         }
     }
 
-    private func createObserverInfo(
-        for element: Element,
-        notification: AXNotification,
-        callback: @escaping AXNotificationCallback) throws -> ObserverInfo
-    {
-        let pid = try pidForElement(element)
-        let observer = try makeObserver(pid: pid)
-        try addNotification(notification, to: observer, element: element)
-
-        let runLoopSource = AXObserverGetRunLoopSource(observer)
-        CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, .defaultMode)
-
-        var callbacks: [CFString: AXNotificationCallback] = [:]
-        callbacks[self.notificationKey(for: notification)] = callback
-
-        axDebugLog("Created observer for PID \(pid) with notification \(notification.rawValue)")
-        return ObserverInfo(observer: observer, runLoopSource: runLoopSource, callbacks: callbacks)
+    private struct Registration {
+        let token: SubscriptionToken
+        let callback: CallbackBox
     }
 
-    private func pidForElement(_ element: Element) throws -> pid_t {
-        guard let pid = element.pid() else {
-            throw ObserverError.other("Could not get PID for element")
+    private final class CallbackBox {
+        var callback: AXNotificationCallback
+
+        init(callback: @escaping AXNotificationCallback) {
+            self.callback = callback
         }
-        return pid
     }
 
-    private func makeObserver(pid: pid_t) throws -> AXObserver {
-        var observer: AXObserver?
-        let axCallback: AXObserverCallbackWithInfo = { observer, element, notification, userInfo, _ in
-            AXObserverManager.shared.handleNotification(
-                observer: observer,
-                element: element,
-                notification: notification,
-                userInfo: userInfo)
-        }
+    private let observationCenter: AXObserverCenter
+    private var registrations: [RegistrationKey: Registration] = [:]
 
-        let creationError = AXObserverCreateWithInfoCallback(
-            pid,
-            axCallback,
-            &observer)
-
-        guard creationError == .success, let observer else {
-            axErrorLog("Failed to create observer: \(creationError)")
-            throw ObserverError.couldNotCreateObserver
-        }
-        return observer
-    }
-
-    private func addNotification(
-        _ notification: AXNotification,
-        to observer: AXObserver,
-        element: Element) throws
-    {
-        let error = AXObserverAddNotification(
-            observer,
-            element.underlyingElement,
-            notification.rawValue as CFString,
-            nil)
-        if error != .success {
-            axErrorLog("Failed to add notification: \(error)")
-            throw ObserverError.addNotificationFailed(error)
+    private func compatibilityError(from error: AXObserverSubscriptionError) -> ObserverError {
+        switch error {
+        case .observerCreationFailed:
+            .couldNotCreateObserver
+        case let .nativeRegistrationFailed(_, _, nativeError):
+            .addNotificationFailed(nativeError)
+        case let .validation(details):
+            .other(details)
         }
     }
 }

--- a/Tests/AXorcistTests/AXObserverManagerCompatibilityTests.swift
+++ b/Tests/AXorcistTests/AXObserverManagerCompatibilityTests.swift
@@ -1,0 +1,185 @@
+import ApplicationServices
+import Foundation
+import Testing
+@testable import AXorcist
+
+@Suite("AXObserverManager compatibility")
+@MainActor
+struct AXObserverManagerCompatibilityTests {
+    @Test
+    func `raw callback identity is preserved and same-key replacement stays logical`() throws {
+        let calls = CompatibilityObserverCalls()
+        let center = self.makeCenter(calls: calls)
+        let manager = AXObserverManager(observationCenter: center)
+        let element = Element(AXUIElementCreateApplication(getpid()))
+        let observer = try self.makeObserver()
+        let userInfo = ["source": "exact"] as CFDictionary
+        var firstCallbackCount = 0
+        let capture = RawObserverCallbackCapture()
+
+        try manager.addObserver(for: element, notification: .valueChanged) { _, _, _, _ in
+            firstCallbackCount += 1
+        }
+        try manager.addObserver(
+            for: element,
+            notification: .valueChanged,
+            callback: capture.record)
+        center.processNotification(AXObserverNotificationEvent(
+            observer: observer,
+            pid: getpid(),
+            notification: .valueChanged,
+            notificationString: AXNotification.valueChanged.rawValue as CFString,
+            rawElement: element.underlyingElement,
+            rawUserInfo: userInfo,
+            userInfo: ["source": "exact"]))
+
+        #expect(calls.setupCount == 1)
+        #expect(firstCallbackCount == 0)
+        #expect(capture.observer === observer)
+        #expect(capture.element === element.underlyingElement)
+        #expect(capture.notification == AXNotification.valueChanged.rawValue as CFString)
+        #expect(capture.userInfo === userInfo)
+
+        try manager.removeObserver(for: element, notification: .valueChanged)
+        #expect(calls.cleanupCount == 1)
+        #expect(!center.isKeyRegistered(pid: getpid(), notification: .valueChanged))
+    }
+
+    @Test
+    func `remove all affects only compatibility-manager tokens`() throws {
+        let calls = CompatibilityObserverCalls()
+        let center = self.makeCenter(calls: calls)
+        let manager = AXObserverManager(observationCenter: center)
+        let element = Element(AXUIElementCreateApplication(getpid()))
+        let unrelated = try center.subscribe(
+            pid: getpid(),
+            element: element,
+            notification: .titleChanged,
+            handler: { _, _, _, _ in }).get()
+        try manager.addObserver(for: element, notification: .valueChanged) { _, _, _, _ in }
+
+        manager.removeAllObservers()
+
+        #expect(!center.isKeyRegistered(pid: getpid(), notification: .valueChanged))
+        #expect(center.isKeyRegistered(pid: getpid(), notification: .titleChanged))
+        #expect(calls.cleanupCount == 1)
+        try center.unsubscribe(token: unrelated)
+        #expect(calls.cleanupCount == 2)
+    }
+
+    @Test
+    func `native add failures retain the legacy typed error`() {
+        let center = AXObserverCenter(
+            observerSetup: { _, _, _ in .cannotComplete },
+            observerCleanup: { _, _, _ in })
+        let manager = AXObserverManager(observationCenter: center)
+        let element = Element(AXUIElementCreateApplication(getpid()))
+
+        do {
+            try manager.addObserver(for: element, notification: .valueChanged) { _, _, _, _ in }
+            Issue.record("Expected the compatibility add to fail")
+        } catch let error as AXObserverManager.ObserverError {
+            guard case .addNotificationFailed(.cannotComplete) = error else {
+                Issue.record("Expected addNotificationFailed(.cannotComplete), got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("Expected AXObserverManager.ObserverError, got \(error)")
+        }
+    }
+
+    @Test
+    func `native remove failure is bounded and retains the compatibility registration for retry`() throws {
+        let removals = CompatibilityRemovalSequence()
+        let generation = UInt64(UInt32(bitPattern: getpid()))
+        let center = AXObserverCenter(
+            processIdentityProvider: { _ in generation },
+            nativeRegistrationWorkProvider: { _, _ in
+                ObserverNativeRegistrationWork(
+                    add: { .success },
+                    remove: removals.next)
+            })
+        let manager = AXObserverManager(observationCenter: center)
+        let element = Element(AXUIElementCreateApplication(getpid()))
+        try manager.addObserver(for: element, notification: .valueChanged) { _, _, _, _ in }
+
+        #expect(throws: AXObserverManager.ObserverError.self) {
+            try manager.removeObserver(for: element, notification: .valueChanged)
+        }
+        #expect(center.isKeyRegistered(pid: getpid(), notification: .valueChanged))
+
+        try manager.removeObserver(for: element, notification: .valueChanged)
+        #expect(!center.isKeyRegistered(pid: getpid(), notification: .valueChanged))
+        #expect(removals.callCount == 2)
+    }
+
+    private func makeCenter(calls: CompatibilityObserverCalls) -> AXObserverCenter {
+        AXObserverCenter(
+            observerSetup: { _, _, _ in
+                calls.recordSetup()
+                return .success
+            },
+            observerCleanup: { _, _, _ in
+                calls.recordCleanup()
+            })
+    }
+
+    private func makeObserver() throws -> AXObserver {
+        var observer: AXObserver?
+        let callback: AXObserverCallbackWithInfo = { _, _, _, _, _ in }
+        let error = AXObserverCreateWithInfoCallback(getpid(), callback, &observer)
+        guard error == .success, let observer else {
+            throw AXObserverManager.ObserverError.couldNotCreateObserver
+        }
+        return observer
+    }
+}
+
+private final class CompatibilityObserverCalls {
+    private(set) var setupCount = 0
+    private(set) var cleanupCount = 0
+
+    func recordSetup() {
+        self.setupCount += 1
+    }
+
+    func recordCleanup() {
+        self.cleanupCount += 1
+    }
+}
+
+@MainActor
+private final class RawObserverCallbackCapture {
+    private(set) var observer: AXObserver?
+    private(set) var element: AXUIElement?
+    private(set) var notification: CFString?
+    private(set) var userInfo: CFDictionary?
+
+    func record(
+        observer: AXObserver,
+        element: AXUIElement,
+        notification: CFString,
+        userInfo: CFDictionary?)
+    {
+        self.observer = observer
+        self.element = element
+        self.notification = notification
+        self.userInfo = userInfo
+    }
+}
+
+private final nonisolated class CompatibilityRemovalSequence: @unchecked Sendable {
+    private let lock = NSLock()
+    private var calls = 0
+
+    func next() -> AXError {
+        self.lock.withLock {
+            self.calls += 1
+            return self.calls == 1 ? .cannotComplete : .success
+        }
+    }
+
+    var callCount: Int {
+        self.lock.withLock { self.calls }
+    }
+}

--- a/Tests/AXorcistTests/ObserverNativePendingAddTests.swift
+++ b/Tests/AXorcistTests/ObserverNativePendingAddTests.swift
@@ -27,19 +27,118 @@ struct ObserverNativePendingAddTests {
 
     @Test
     func `sync join parks a waiter so late success commits`() {
-        let completion = NativeRemovalCompletion()
-        #expect(completion.waiterCount == 0)
-        completion.parkWaiter()
-        #expect(completion.waiterCount == 1)
+        let completion = NativeAddCompletion()
+        #expect(completion.beginSynchronousWait())
+        let outcome = ObserverNativeWork.PendingNativeFirstResult(error: .success, timedOut: true)
+        #expect(completion.finishNative(with: outcome) == .synchronous)
+        #expect(completion.waiterCountAtNativeFinish == 1)
         #expect(
             ObserverNativeWork.pendingAddDisposition(
                 nativeError: .success,
                 stillPending: true,
-                waiterCount: completion.waiterCount,
+                waiterCount: completion.waiterCountAtNativeFinish,
                 generationMatches: true,
                 isLate: true) == .commit)
-        completion.unparkWaiter()
-        #expect(completion.waiterCount == 0)
+        #expect(completion.waitForNativeResult(
+            until: ContinuousClock().now.advanced(by: .seconds(1))) == outcome)
+    }
+
+    @Test
+    func `native result does not wake async joiners before resolution`() async {
+        let completion = NativeAddCompletion()
+        let returned = PendingAddResultBox()
+        let waiter = Task {
+            let outcome = await completion.value(timeout: .seconds(30))
+            returned.store(outcome.error)
+            return outcome
+        }
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(5))
+        while completion.resolutionWaiterCount == 0, clock.now < deadline {
+            await Task.yield()
+        }
+        #expect(completion.resolutionWaiterCount == 1)
+        let native = ObserverNativeWork.PendingNativeFirstResult(error: .success, timedOut: false)
+
+        #expect(completion.finishNative(with: native) == .asynchronous)
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+        #expect(returned.value == nil)
+
+        let resolved = ObserverNativeWork.PendingNativeFirstResult(error: .cannotComplete, timedOut: false)
+        completion.publishResolved(resolved)
+        #expect(await waiter.value == resolved)
+    }
+
+    @Test
+    func `timed out async joiner no longer authorizes a late commit`() async {
+        let completion = NativeAddCompletion()
+        let waiter = Task {
+            await completion.value(timeout: .milliseconds(20))
+        }
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while completion.resolutionWaiterCount == 0, clock.now < deadline {
+            await Task.yield()
+        }
+        #expect(completion.finishNative(with: ObserverNativeWork.PendingNativeFirstResult(
+            error: .success,
+            timedOut: true)) == .asynchronous)
+
+        #expect(await waiter.value.error == .cannotComplete)
+        #expect(completion.resolutionWaiterCount == 0)
+    }
+
+    @Test
+    func `sync deadline atomically hands a later native result to async resolution`() {
+        let completion = NativeAddCompletion()
+        #expect(completion.beginSynchronousWait())
+        let clock = ContinuousClock()
+
+        #expect(completion.waitForNativeResult(until: clock.now) == nil)
+        #expect(completion.finishNative(with: ObserverNativeWork.PendingNativeFirstResult(
+            error: .success,
+            timedOut: true)) == .asynchronous)
+    }
+
+    @Test
+    func `sync join can claim a native-ready result before async resolution starts`() {
+        let completion = NativeAddCompletion()
+        let outcome = ObserverNativeWork.PendingNativeFirstResult(error: .success, timedOut: true)
+        #expect(completion.finishNative(with: outcome) == .asynchronous)
+
+        #expect(completion.beginSynchronousWait())
+        #expect(completion.waitForNativeResult(
+            until: ContinuousClock().now.advanced(by: .seconds(1))) == outcome)
+        #expect(!completion.beginAsynchronousResolution())
+    }
+
+    @Test @MainActor
+    func `resolved setup never adopts another process generation`() {
+        let center = AXObserverCenter(
+            observerSetup: { _, _, _ in .success },
+            observerCleanup: { _, _, _ in })
+        let registration = AXObserverRegistrationKey(
+            subscription: AXNotificationSubscriptionKey(pid: 42, notification: .valueChanged),
+            element: Element(AXUIElementCreateApplication(42)),
+            scope: .process)
+        center.nativeRegistrationStates[registration] = AXObserverCenter.NativeRegistrationState(
+            operationID: UUID(),
+            processGeneration: 2)
+        let completion = NativeAddCompletion()
+        completion.publishResolved(ObserverNativeWork.PendingNativeFirstResult(
+            error: .success,
+            timedOut: false))
+
+        let result = center.registrationSetupResult(
+            registration,
+            expectedGeneration: 1,
+            completion: completion,
+            fallbackError: .success)
+
+        #expect(result.error == .cannotComplete)
+        #expect(result.state == nil)
     }
 
     @Test

--- a/Tests/AXorcistTests/ObserverNativeWorkTests.swift
+++ b/Tests/AXorcistTests/ObserverNativeWorkTests.swift
@@ -67,31 +67,6 @@ struct ObserverNativeWorkTests {
     }
 
     @Test
-    func `synchronous cleanup distinguishes saturation from a native result`() {
-        let admission = ObserverNativeWorkerAdmission()
-        for _ in 0..<ObserverNativeWorkerAdmission.maximumRegularWorkers {
-            #expect(admission.tryAcquire())
-        }
-        #expect(admission.tryAcquireCleanup())
-        var executed = false
-
-        let refused = ObserverNativeWork.tryPerformCleanupSynchronously(admission: admission) {
-            executed = true
-            return AXError.success
-        }
-        #expect(refused == nil)
-        #expect(!executed)
-
-        admission.release()
-        let admitted = ObserverNativeWork.tryPerformCleanupSynchronously(admission: admission) {
-            executed = true
-            return AXError.success
-        }
-        #expect(admitted == .success)
-        #expect(executed)
-    }
-
-    @Test
     func `synchronous native removal join has a monotonic deadline`() {
         let completion = NativeRemovalCompletion()
         let clock = ContinuousClock()

--- a/Tests/AXorcistTests/ObserverSynchronousLifecycleTests.swift
+++ b/Tests/AXorcistTests/ObserverSynchronousLifecycleTests.swift
@@ -195,7 +195,7 @@ struct ObserverSynchronousLifecycleTests {
 
     private func waitForPendingWorkToDrain(_ center: AXObserverCenter) async {
         let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(2))
+        let deadline = clock.now.advanced(by: .seconds(10))
         while !center.pendingRegistrations.isEmpty || !center.pendingRemovals.isEmpty,
               clock.now < deadline
         {

--- a/Tests/AXorcistTests/ObserverSynchronousLifecycleTests.swift
+++ b/Tests/AXorcistTests/ObserverSynchronousLifecycleTests.swift
@@ -1,0 +1,227 @@
+import ApplicationServices
+import Foundation
+import Testing
+@testable import AXorcist
+
+@Suite("Synchronous observer lifecycle", .serialized)
+@MainActor
+struct ObserverSynchronousLifecycleTests {
+    @Test
+    func `synchronous subscribe fails closed while a late add remains owned for rollback`() async {
+        let addRelease = DispatchSemaphore(value: 0)
+        let calls = ObserverWorkCalls()
+        let center = self.makeCenter(
+            add: {
+                calls.recordAdd()
+                addRelease.wait()
+                return .success
+            },
+            remove: {
+                calls.recordRemove()
+                return .success
+            })
+        let clock = ContinuousClock()
+        let started = clock.now
+
+        let result = center.subscribe(
+            pid: getpid(),
+            element: Element(AXUIElementCreateSystemWide()),
+            notification: .valueChanged,
+            handler: { _, _, _, _ in })
+
+        #expect(started.duration(to: clock.now) < .seconds(3))
+        guard case .failure = result else {
+            Issue.record("Expected a bounded synchronous registration failure")
+            addRelease.signal()
+            return
+        }
+        #expect(calls.addCount == 1)
+        #expect(center.pendingRegistrations.count == 1)
+        #expect(center.registeredKeys.isEmpty)
+
+        addRelease.signal()
+        await self.waitForPendingWorkToDrain(center)
+
+        #expect(calls.removeCount == 1)
+        #expect(center.pendingRegistrations.isEmpty)
+        #expect(center.pendingRemovals.isEmpty)
+        #expect(center.nativeRegistrationStates.isEmpty)
+    }
+
+    @Test
+    func `late add commits while the synchronous waiter is still live`() async throws {
+        let addRelease = DispatchSemaphore(value: 0)
+        let calls = ObserverWorkCalls()
+        let center = self.makeCenter(
+            add: {
+                calls.recordAdd()
+                addRelease.wait()
+                return .success
+            },
+            remove: {
+                calls.recordRemove()
+                return .success
+            })
+        Task.detached {
+            try? await Task.sleep(for: .milliseconds(650))
+            addRelease.signal()
+        }
+        let clock = ContinuousClock()
+        let started = clock.now
+
+        let token = try center.subscribe(
+            pid: getpid(),
+            element: Element(AXUIElementCreateSystemWide()),
+            notification: .valueChanged,
+            handler: { _, _, _, _ in }).get()
+
+        #expect(started.duration(to: clock.now) < .seconds(2))
+        #expect(calls.addCount == 1)
+        #expect(center.nativeRegistrationStates.count == 1)
+        try center.unsubscribe(token: token)
+        await self.waitForPendingWorkToDrain(center)
+        #expect(calls.removeCount == 1)
+    }
+
+    @Test
+    func `synchronous retry joins one in-flight add instead of launching a duplicate`() async throws {
+        let addRelease = DispatchSemaphore(value: 0)
+        let calls = ObserverWorkCalls()
+        let center = self.makeCenter(
+            add: {
+                calls.recordAdd()
+                addRelease.wait()
+                return .success
+            },
+            remove: {
+                calls.recordRemove()
+                return .success
+            })
+        let element = Element(AXUIElementCreateSystemWide())
+        let first = center.subscribe(
+            pid: getpid(),
+            element: element,
+            notification: .valueChanged,
+            handler: { _, _, _, _ in })
+        guard case .failure = first else {
+            Issue.record("Expected the first bounded join to time out")
+            addRelease.signal()
+            return
+        }
+        Task.detached {
+            try? await Task.sleep(for: .milliseconds(100))
+            addRelease.signal()
+        }
+
+        let token = try center.subscribe(
+            pid: getpid(),
+            element: element,
+            notification: .valueChanged,
+            handler: { _, _, _, _ in }).get()
+
+        #expect(calls.addCount == 1)
+        try center.unsubscribe(token: token)
+        await self.waitForPendingWorkToDrain(center)
+        #expect(calls.removeCount == 1)
+    }
+
+    @Test
+    func `synchronous unsubscribe returns while native removal remains pending`() async throws {
+        let removeRelease = DispatchSemaphore(value: 0)
+        let calls = ObserverWorkCalls()
+        let center = self.makeCenter(
+            add: {
+                calls.recordAdd()
+                return .success
+            },
+            remove: {
+                calls.recordRemove()
+                if calls.removeCount == 1 {
+                    removeRelease.wait()
+                }
+                return .success
+            })
+        let element = Element(AXUIElementCreateSystemWide())
+        let token = try center.subscribe(
+            pid: getpid(),
+            element: element,
+            notification: .valueChanged,
+            handler: { _, _, _, _ in }).get()
+        let clock = ContinuousClock()
+        let started = clock.now
+
+        try center.unsubscribe(token: token)
+
+        #expect(started.duration(to: clock.now) < .seconds(1))
+        #expect(center.pendingRemovals.count == 1)
+        let refused = center.subscribe(
+            pid: getpid(),
+            element: element,
+            notification: .valueChanged,
+            handler: { _, _, _, _ in })
+        guard case .failure = refused else {
+            Issue.record("Expected resubscribe to refuse unconfirmed removal")
+            removeRelease.signal()
+            return
+        }
+        #expect(calls.addCount == 1)
+        removeRelease.signal()
+        await self.waitForPendingWorkToDrain(center)
+        #expect(calls.removeCount == 1)
+        #expect(center.nativeRegistrationStates.isEmpty)
+
+        let replacement = try center.subscribe(
+            pid: getpid(),
+            element: element,
+            notification: .valueChanged,
+            handler: { _, _, _, _ in }).get()
+        #expect(calls.addCount == 2)
+        try center.unsubscribe(token: replacement)
+        await self.waitForPendingWorkToDrain(center)
+        #expect(calls.removeCount == 2)
+    }
+
+    private func makeCenter(
+        add: @escaping @Sendable () -> AXError,
+        remove: @escaping @Sendable () -> AXError) -> AXObserverCenter
+    {
+        let generation = UInt64(UInt32(bitPattern: getpid()))
+        return AXObserverCenter(
+            processIdentityProvider: { _ in generation },
+            nativeRegistrationWorkProvider: { _, _ in
+                ObserverNativeRegistrationWork(add: add, remove: remove)
+            })
+    }
+
+    private func waitForPendingWorkToDrain(_ center: AXObserverCenter) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while !center.pendingRegistrations.isEmpty || !center.pendingRemovals.isEmpty,
+              clock.now < deadline
+        {
+            await Task.yield()
+        }
+    }
+}
+
+private final nonisolated class ObserverWorkCalls: @unchecked Sendable {
+    private let lock = NSLock()
+    private var adds = 0
+    private var removes = 0
+
+    func recordAdd() {
+        self.lock.withLock { self.adds += 1 }
+    }
+
+    func recordRemove() {
+        self.lock.withLock { self.removes += 1 }
+    }
+
+    var addCount: Int {
+        self.lock.withLock { self.adds }
+    }
+
+    var removeCount: Int {
+        self.lock.withLock { self.removes }
+    }
+}


### PR DESCRIPTION
## Summary

- route synchronous and asynchronous AX registrations through one pending-add state machine
- atomically hand raw native results to exactly one synchronous or asynchronous resolver before publishing resolved commit/rollback state
- make all final-token cleanup asynchronous and late-result-owned, with bounded compatibility removal joins
- reduce the deprecated `AXObserverManager` to a token adapter over `AXObserverCenter` while preserving exact raw callback identity and typed add/remove behavior

## Safety properties

- a wedged element-scoped add cannot block the main actor indefinitely
- retries join one in-flight add and cannot duplicate native registration
- late success commits only for a live waiter; otherwise it is rolled back
- PID-generation drift cannot adopt another generation's native state
- async joiners wake only after commit or rollback resolution
- unconfirmed compatibility removal retains its token and can retry

## Test plan

- `swift test` — 201 tests passed across the library and command-conversion targets
- focused synchronous lifecycle suite — 4/4
- focused pending-add suite — 16/16
- compatibility-manager suite — 4/4
- live native smoke — registered `AXFocusedUIElementChanged` against Safari PID 33548, received the successful observe receipt, remained active, and cancelled cleanly
- `make check` — SwiftFormat, strict SwiftLint, and both native-only policy gates passed
- structured P0/P1 autoreview — clean after addressing all findings

No release or version publication is included.
