### PR TITLE
fix: decode raw JSON locator paths and report field errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add immutable per-request accessibility traversal options while keeping the legacy process defaults source-compatible and thread-safe.
 
 ### Fixed
+- Decode documented `path_from_root` locators without requiring `criteria`, preserve their navigation hints, and report precise raw JSON field errors; clarify the CLI and JSON command names. Thanks @pixel-placebo-lab.
 - Route synchronous and legacy element observation through the shared bounded registration and cleanup state machine, so a wedged Accessibility endpoint cannot block the main actor indefinitely or escape late-result rollback.
 - Bound asynchronous AX notification add and remove waits, including removal joins and subscription setup retries, so a wedged Accessibility endpoint cannot hang global observer startup or teardown. Thanks @SebTardif.
 - Refuse per-element Accessibility reads when macOS cannot arm their messaging deadline, and report any failure to clear an armed deadline after the protected operation.

--- a/README.md
+++ b/README.md
@@ -558,7 +558,24 @@ Run `axorc --help` or `axorc help find` for the complete terminal reference. Hum
 
 ### JSON Protocol
 
-Every JSON command requires `command_id` and `command`. Input can come from standard input, a file, an argument, or the legacy root-level syntax:
+Every JSON command requires `command_id` and `command`. JSON command names and fields differ from the human-readable CLI:
+
+| CLI | JSON protocol |
+| --- | --- |
+| `tree --app <app> --depth 3` | `"command":"collectAll", "application":"<app>", "max_depth":3` |
+| `find --app <app> --role AXButton` | `"command":"query", "application":"<app>", "locator":{"criteria":[{"attribute":"AXRole","value":"AXButton"}]}` |
+
+`tree` and `find` are not JSON command names. Use `application` and `max_depth`, not `app` and `depth`. For example, the raw equivalent of `axorc tree --app com.apple.mail --depth 3 --json` is:
+
+```bash
+axorc raw --json '{"command_id":"mail-tree","command":"collectAll","application":"com.apple.mail","max_depth":3,"attributes":["AXRole","AXTitle","AXDescription","AXIdentifier","AXValue"]}'
+```
+
+Protocol commands are `ping`, `query`, `getAttributes`, `describeElement`, `getElementAtPoint`, `getFocusedElement`, `performAction`, `batch`, `observe`, `collectAll`, `stopObservation`, `isProcessTrusted`, `isAXFeatureEnabled`, `setFocusedValue`, and `extractText`. The reserved names `setNotificationHandler`, `removeNotificationHandler`, and `getElementDescription` decode but return a not-implemented error.
+
+Locators may contain `criteria`, `path_from_root`, or both; omitted `criteria` defaults to an empty list. Invalid payloads return a nonzero exit code and a JSON error with the failing field path. An application-not-found or Accessibility error means decoding succeeded and the command reached execution.
+
+Input can come from standard input, a file, an argument, or the legacy root-level syntax:
 
 ```bash
 # Standard input

--- a/Sources/AXorcist/Core/MatchingTypes.swift
+++ b/Sources/AXorcist/Core/MatchingTypes.swift
@@ -121,6 +121,22 @@ public struct Locator: Codable, Sendable {
         self.debugPathSearch = debugPathSearch
     }
 
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.matchAll = try container.decodeIfPresent(Bool.self, forKey: .matchAll)
+        self.criteria = try container.decodeIfPresent([Criterion].self, forKey: .criteria) ?? []
+        self.descendantCriteria = try container.decodeIfPresent([String: String].self, forKey: .descendantCriteria)
+        self.requireAction = try container.decodeIfPresent(String.self, forKey: .requireAction)
+        self.computedNameContains = try container.decodeIfPresent(String.self, forKey: .computedNameContains)
+        self.debugPathSearch = try container.decodeIfPresent(Bool.self, forKey: .debugPathSearch)
+
+        // Preserve the published default Codable key as well as the CLI's snake-case decoding strategy.
+        let pathContainer = try decoder.container(keyedBy: ConvertedPathCodingKeys.self)
+        self.rootElementPathHint = try container.decodeIfPresent(
+            [JSONPathHintComponent].self, forKey: .rootElementPathHint)
+            ?? pathContainer.decodeIfPresent([JSONPathHintComponent].self, forKey: .pathFromRoot)
+    }
+
     // MARK: Public
 
     public var matchAll: Bool? // For the top-level criteria, if path_from_root is not used or fails early.
@@ -142,5 +158,9 @@ public struct Locator: Codable, Sendable {
         case requireAction
         case computedNameContains
         case debugPathSearch
+    }
+
+    private enum ConvertedPathCodingKeys: String, CodingKey {
+        case pathFromRoot
     }
 }

--- a/Sources/axorc/AXORCMain.swift
+++ b/Sources/axorc/AXORCMain.swift
@@ -237,8 +237,6 @@ struct AXORCCommand: ParsableCommand {
         axorcist: AXorcist,
         traversalOptions: AXTraversalOptions) throws
     {
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
         guard let data = jsonString.data(using: .utf8) else {
             axDebugLog("AXORCMain Test: Failed to convert jsonStringFromInput to data.")
             self.respondWithError(
@@ -250,19 +248,15 @@ struct AXORCCommand: ParsableCommand {
 
         let commands: [CommandEnvelope]
         do {
-            commands = try decoder.decode([CommandEnvelope].self, from: data)
-        } catch let arrayDecodeError {
-            self.logDebug("Array decode failed: \(arrayDecodeError). Trying a single command.")
-            do {
-                commands = try [decoder.decode(CommandEnvelope.self, from: data)]
-            } catch let singleDecodeError {
-                self.logDebug("Single-command decode failed: \(singleDecodeError).")
-                self.respondWithError(
-                    commandId: "decode_error",
-                    error: "Failed to decode JSON input: \(singleDecodeError.localizedDescription)",
-                    logs: self.debug ? axGetLogsAsStrings() : nil)
-                throw ExitCode.failure
-            }
+            commands = try InputHandler.decodeCommands(from: data)
+        } catch {
+            self.logDebug("Command decode failed: \(error).")
+            let detail = (error as? DecodingError)?.humanReadableDescription ?? error.localizedDescription
+            self.respondWithError(
+                commandId: "decode_error",
+                error: "Failed to decode JSON input: \(detail)",
+                logs: self.debug ? axGetLogsAsStrings() : nil)
+            throw ExitCode.failure
         }
 
         guard let command = commands.first else {

--- a/Sources/axorc/CLIFrontend.swift
+++ b/Sources/axorc/CLIFrontend.swift
@@ -354,6 +354,8 @@ enum CLIFrontend {
 
     Every command requires command_id and command fields. Legacy root-level
     raw invocations remain supported.
+    JSON uses collectAll/query, not the tree/find CLI names, and application/
+    max_depth, not app/depth. See the README's JSON Protocol examples.
 
     EXAMPLE:
       echo '{"command_id":"health","command":"ping"}' | axorc raw --stdin

--- a/Sources/axorc/Core/InputHandler.swift
+++ b/Sources/axorc/Core/InputHandler.swift
@@ -14,6 +14,12 @@ enum InputHandler {
 
     typealias Result = ParseResult
 
+    static func decodeCommands(from data: Data) throws -> [CommandEnvelope] {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(CommandInput.self, from: data).commands
+    }
+
     static func parseInput(
         stdin: Bool,
         file: String?,
@@ -49,6 +55,19 @@ enum InputHandler {
     }
 
     // MARK: Private
+
+    private struct CommandInput: Decodable {
+        let commands: [CommandEnvelope]
+
+        init(from decoder: any Decoder) throws {
+            // Probe only the container shape; a malformed array entry must keep its own decoding error.
+            if (try? decoder.unkeyedContainer()) != nil {
+                self.commands = try [CommandEnvelope](from: decoder)
+            } else {
+                self.commands = try [CommandEnvelope(from: decoder)]
+            }
+        }
+    }
 
     // MARK: - Helper Functions
 

--- a/Tests/AXorcistCommandConversionTests/LocatorWireTests.swift
+++ b/Tests/AXorcistCommandConversionTests/LocatorWireTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import axorc
+@testable import AXorcist
+
+@Suite("Locator wire contract")
+struct LocatorWireTests {
+    @Test(arguments: [false, true])
+    func `Published path key survives both decoder strategies`(snakeCase: Bool) throws {
+        let json = """
+        {"criteria":[],"path_from_root":[{"attribute":"AXTitle","value":"Main","depth":2}]}
+        """
+        let locator = try self.decode(json, snakeCase: snakeCase)
+        let hint = try #require(locator.rootElementPathHint?.first)
+        #expect(hint.attribute == "AXTitle")
+        #expect(hint.value == "Main")
+        #expect(hint.depth == 2)
+    }
+
+    @Test(arguments: [false, true])
+    func `Path-only locator uses empty criteria`(snakeCase: Bool) throws {
+        let locator = try self.decode(
+            #"{"path_from_root":[{"attribute":"AXRole","value":"AXWindow"}]}"#,
+            snakeCase: snakeCase)
+        #expect(locator.criteria.isEmpty)
+        #expect(locator.rootElementPathHint?.count == 1)
+    }
+
+    @Test(arguments: [false, true])
+    func `Published encoding keeps path_from_root`(snakeCase: Bool) throws {
+        let locator = Locator(rootElementPathHint: [
+            JSONPathHintComponent(attribute: "AXTitle", value: "Main", depth: 2),
+        ])
+        let encoder = JSONEncoder()
+        if snakeCase {
+            encoder.keyEncodingStrategy = .convertToSnakeCase
+        }
+        let data = try encoder.encode(locator)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["path_from_root"] != nil)
+        #expect(object["pathFromRoot"] == nil)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try self.decode(json, snakeCase: snakeCase)
+        #expect(decoded.rootElementPathHint?.first?.value == "Main")
+    }
+
+    @Test
+    func `Documented query path and snake case options reach the library command`() throws {
+        let json = """
+        {"command_id":"path-query","command":"query","application":"Finder","max_depth":7,
+         "locator":{"path_from_root":[{"attribute":"AXTitle","value":"Main","match_type":"prefix"}],
+         "criteria":[{"attribute":"AXRole","value":"AXButton","match_type":"contains"}],
+         "matchAll":false,"require_action":"AXPress","debug_path_search":true}}
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let envelope = try decoder.decode(CommandEnvelope.self, from: Data(json.utf8))
+        guard case let .query(query) = envelope.command.toAXCommand(commandEnvelope: envelope) else {
+            Issue.record("Expected query conversion")
+            return
+        }
+        #expect(query.appIdentifier == "Finder")
+        #expect(query.maxDepthForSearch == 7)
+        #expect(query.locator.rootElementPathHint?.first?.matchType == .prefix)
+        #expect(query.locator.criteria.first?.matchType == .contains)
+        #expect(query.locator.matchAll == false)
+        #expect(query.locator.requireAction == "AXPress")
+        #expect(query.locator.debugPathSearch == true)
+    }
+
+    private func decode(_ json: String, snakeCase: Bool) throws -> Locator {
+        let decoder = JSONDecoder()
+        if snakeCase {
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+        }
+        return try decoder.decode(Locator.self, from: Data(json.utf8))
+    }
+}

--- a/Tests/AXorcistTests/CommonTestHelpers.swift
+++ b/Tests/AXorcistTests/CommonTestHelpers.swift
@@ -27,7 +27,7 @@ enum AXTestEnvironment {
 }
 
 /// Result struct for AXORC commands
-struct CommandResult {
+nonisolated struct CommandResult: Sendable {
     let output: String?
     let errorOutput: String?
     let exitCode: Int32
@@ -164,7 +164,7 @@ func closeTextEdit() async {
     }
 }
 
-func runAXORCCommand(arguments: [String]) throws -> CommandResult {
+nonisolated func runAXORCCommand(arguments: [String]) throws -> CommandResult {
     let axorcUrl = productsDirectory.appendingPathComponent("axorc")
 
     let process = Process()
@@ -195,7 +195,7 @@ func runAXORCCommand(arguments: [String]) throws -> CommandResult {
     return CommandResult(output: cleanOutput, errorOutput: errorOutput, exitCode: process.terminationStatus)
 }
 
-func createTempFile(content: String) throws -> String {
+nonisolated func createTempFile(content: String) throws -> String {
     let tempDir = FileManager.default.temporaryDirectory
     let fileName = UUID().uuidString + ".json"
     let fileURL = tempDir.appendingPathComponent(fileName)
@@ -203,7 +203,7 @@ func createTempFile(content: String) throws -> String {
     return fileURL.path
 }
 
-func stripJSONPrefix(from output: String?) -> String? {
+nonisolated func stripJSONPrefix(from output: String?) -> String? {
     guard let output else { return nil }
     let prefix = "AXORC_JSON_OUTPUT_PREFIX:::"
     if output.hasPrefix(prefix) {
@@ -212,7 +212,7 @@ func stripJSONPrefix(from output: String?) -> String? {
     return output
 }
 
-func runAXORCCommandWithStdin(inputJSON: String, arguments: [String]) throws -> CommandResult {
+nonisolated func runAXORCCommandWithStdin(inputJSON: String, arguments: [String]) throws -> CommandResult {
     let axorcUrl = productsDirectory.appendingPathComponent("axorc")
 
     let process = Process()
@@ -473,7 +473,7 @@ enum TestError: Error, CustomStringConvertible {
 
 // MARK: - Helper Properties
 
-var productsDirectory: URL {
+nonisolated var productsDirectory: URL {
     #if os(macOS)
     for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
         return bundle.bundleURL.deletingLastPathComponent()

--- a/Tests/AXorcistTests/CommonTestHelpers.swift
+++ b/Tests/AXorcistTests/CommonTestHelpers.swift
@@ -10,8 +10,8 @@ extension Comment {
 }
 
 extension Tag {
-    @Tag static var safe: Self
-    @Tag static var automation: Self
+    @Tag nonisolated static var safe: Self
+    @Tag nonisolated static var automation: Self
 }
 
 @preconcurrency

--- a/Tests/AXorcistTests/RawProtocolTests.swift
+++ b/Tests/AXorcistTests/RawProtocolTests.swift
@@ -1,8 +1,9 @@
 import Foundation
 import Testing
 
-@Suite("Raw JSON wire protocol", .tags(.safe))
-struct RawProtocolTests {
+/// Subprocess waits must leave MainActor free for observer lifecycle tests running alongside this suite.
+@Suite("Raw JSON wire protocol", .tags(.safe), .serialized)
+nonisolated struct RawProtocolTests {
     @Test(arguments: ["json", "stdin", "file"])
     func `Every protocol command reaches dispatch through every input source`(source: String) throws {
         let commands = [
@@ -107,6 +108,7 @@ struct RawProtocolTests {
     }
 
     private func run(_ payload: String, source: String) throws -> CommandResult {
+        #expect(!Thread.isMainThread, "Blocking subprocess waits must not occupy the main actor")
         switch source {
         case "stdin":
             return try runAXORCCommandWithStdin(inputJSON: payload, arguments: ["raw", "--timeout", "1"])

--- a/Tests/AXorcistTests/RawProtocolTests.swift
+++ b/Tests/AXorcistTests/RawProtocolTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+
+@Suite("Raw JSON wire protocol", .tags(.safe))
+struct RawProtocolTests {
+    @Test(arguments: ["json", "stdin", "file"])
+    func `Every protocol command reaches dispatch through every input source`(source: String) throws {
+        let commands = [
+            "ping", "query", "getAttributes", "describeElement", "getElementAtPoint", "getFocusedElement",
+            "performAction", "batch", "observe", "collectAll", "stopObservation", "isProcessTrusted",
+            "isAXFeatureEnabled", "setFocusedValue", "extractText", "setNotificationHandler",
+            "removeNotificationHandler", "getElementDescription",
+        ]
+        for command in commands {
+            let payload = self.payload(command: command)
+            let result = try self.run(payload, source: source)
+            let object = try self.response(result)
+            #expect(object["command_id"] as? String == command, "\(command), \(source): \(object)")
+            #expect(result.errorOutput?.isEmpty ?? true)
+            #expect(result.exitCode == 0 || result.exitCode == 1)
+        }
+    }
+
+    @Test(arguments: ["json", "stdin", "file"])
+    func `Path-only locators decode without criteria`(source: String) throws {
+        let payload = """
+        {"command_id":"path-only","command":"query","application":"com.example.axorc.protocol-test-missing",
+         "locator":{"path_from_root":[{"attribute":"AXRole","value":"AXWindow"}]}}
+        """
+        let result = try self.run(payload, source: source)
+        let object = try self.response(result)
+        #expect(object["command_id"] as? String == "path-only")
+        #expect(object["command_type"] as? String == "query")
+        #expect(result.exitCode == 1) // The nonexistent application fails after decoding.
+    }
+
+    @Test(arguments: ["tree", "find"])
+    func `CLI-only names explain the invalid command`(command: String) throws {
+        let result = try self.run(
+            "{\"command_id\":\"invalid\",\"command\":\"\(command)\",\"app\":\"Finder\",\"depth\":3}",
+            source: "json")
+        let message = try self.decodeError(result)
+        #expect(message.contains(command))
+        #expect(message.contains("at command"))
+    }
+
+    @Test(arguments: [false, true])
+    func `Malformed nested fields report their actual path for objects and arrays`(array: Bool) throws {
+        let payload = """
+        {"command_id":"invalid-path","command":"query","locator":{"criteria":[],"path_from_root":"invalid"}}
+        """
+        let result = try self.run(array ? "[\(payload)]" : payload, source: "json")
+        let message = try self.decodeError(result)
+        #expect(message.contains("locator.pathFromRoot"))
+        #expect(message.contains("Type mismatch"))
+        if array {
+            #expect(message.contains("Index 0"))
+        }
+    }
+
+    @Test
+    func `Nested batch decode errors retain the subcommand path`() throws {
+        let payload = """
+        {"command_id":"batch","command":"batch","sub_commands":[
+          {"command_id":"bad","command":"query","locator":{"criteria":"invalid"}}]}
+        """
+        let message = try self.decodeError(self.run(payload, source: "json"))
+        #expect(message.contains("subCommands.Index 0.locator.criteria"))
+    }
+
+    @Test(arguments: [false, true])
+    func `Valid command arrays still decode including a UTF8 BOM`(bom: Bool) throws {
+        let payload = (bom ? "\u{FEFF}" : "") + " \n[{\"command_id\":\"array\",\"command\":\"ping\"}]"
+        let result = try self.run(payload, source: "json")
+        let object = try self.response(result)
+        #expect(object["command_id"] as? String == "array")
+        #expect(result.exitCode == 0)
+    }
+
+    @Test
+    func `Empty command arrays remain a structured error`() throws {
+        let message = try self.decodeError(self.run("[]", source: "json"))
+        #expect(message == "JSON command array must not be empty")
+    }
+
+    private func payload(command: String) -> String {
+        // A nonexistent application keeps action and observer dispatch safe on developer machines.
+        let target = "com.example.axorc.protocol-test-missing"
+        let options = switch command {
+        case "performAction": #", "action_name":"AXPress""#
+        case "setFocusedValue": #", "action_value":"test value""#
+        case "getElementAtPoint": #", "point":[500,300]"#
+        case "observe": #", "notifications":["AXValueChanged"], "watch_children":false"#
+        case "batch": """
+            ,"sub_commands":[
+              {"command_id":"nested-query","command":"query","application":"\(target)"},
+              {"command_id":"nested-value","command":"setFocusedValue","application":"\(target)",
+               "action_value":"test value"}]
+            """
+        default: ""
+        }
+        return """
+        {"command_id":"\(command)","command":"\(command)","application":"\(target)",
+         "locator":{"criteria":[{"attribute":"AXRole","value":"AXButton","match_type":"exact"}]},
+         "attributes":["AXRole","AXTitle"],"max_depth":3\(options)}
+        """
+    }
+
+    private func run(_ payload: String, source: String) throws -> CommandResult {
+        switch source {
+        case "stdin":
+            return try runAXORCCommandWithStdin(inputJSON: payload, arguments: ["raw", "--timeout", "1"])
+        case "file":
+            let path = try createTempFile(content: payload)
+            defer { try? FileManager.default.removeItem(atPath: path) }
+            return try runAXORCCommand(arguments: ["raw", "--file", path, "--timeout", "1"])
+        default:
+            return try runAXORCCommand(arguments: ["raw", "--json", payload, "--timeout", "1"])
+        }
+    }
+
+    private func response(_ result: CommandResult) throws -> [String: Any] {
+        let data = try #require(result.output?.data(using: .utf8))
+        return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func decodeError(_ result: CommandResult) throws -> String {
+        let object = try self.response(result)
+        #expect(result.exitCode == 1)
+        #expect(result.errorOutput?.isEmpty ?? true)
+        #expect(object["command_id"] as? String == "decode_error")
+        #expect(object["success"] as? Bool == false)
+        let error = try #require(object["error"] as? [String: Any])
+        return try #require(error["message"] as? String)
+    }
+}

--- a/Tests/AXorcistTests/Support/PipeStreaming.swift
+++ b/Tests/AXorcistTests/Support/PipeStreaming.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-private final class PipeStreamBuffer: @unchecked Sendable {
+private final nonisolated class PipeStreamBuffer: @unchecked Sendable {
     private let queue = DispatchQueue(
         label: "axorcist.tests.pipe-stream.\(UUID().uuidString)",
         qos: .userInitiated)
@@ -18,7 +18,7 @@ private final class PipeStreamBuffer: @unchecked Sendable {
 }
 
 @discardableResult
-func startStreaming(pipe: Pipe) -> () -> Data {
+nonisolated func startStreaming(pipe: Pipe) -> () -> Data {
     let buffer = PipeStreamBuffer()
     let group = DispatchGroup()
 


### PR DESCRIPTION
The report in #51 exposes two problems hidden by the generic raw JSON error. The human CLI names `tree`/`find` are not protocol commands (`collectAll`/`query`), and their `app`/`depth` options are named `application`/`max_depth` in JSON. Valid query and action payloads decode on both v0.1.6 and current main; this is not an all-command v0.1.6 regression.

There are reproducible locator defects: synthesized decoding requires `criteria` even for a documented path-only locator, and the CLI's snake-case decoder transforms `path_from_root` into a key that the locator never reads. A malformed array entry also loses its actual error when the CLI retries the entire input as an object.

This change decodes path-only locators, preserves navigation hints under both default and snake-case decoding, retains the published `path_from_root` encoding, and reports the failing field path without replacing array-entry errors. README examples and raw help explain the CLI/protocol mapping. It adds no command aliases and does not change action implementations.

Proof:

- Built and exercised the v0.1.6 tag (`dba24f0`) and unmodified main (`87242ce`) with the real CLI across `--json`, `--stdin`, and `--file`. Valid non-ping commands reach dispatch; path-only locators fail and malformed paths are ignored before the fix.
- Verified the published v0.1.6 universal archive's checksum and signature; both ARM and Intel slices reproduce the same results. Intel execution used Rosetta on macOS 26, not an Intel Sonoma machine.
- New regression tests fail before the fix and pass afterward. The wire matrix covers all 18 recognized command names through all three input sources, plus nested batch errors, array-entry diagnostics, empty arrays, and BOM-prefixed arrays. Locator tests verify navigation survives command conversion and public Codable round trips.
- Full `swift test -j 4` passed (207 tests reported in the main test target; 5 in the conversion target). Eighteen opt-in UI automation tests were skipped. Independent live Dock `query`/`collectAll` reads succeeded before and after the fix, including both slices of the fixed universal binary.
- `make check` with the repository-pinned SwiftFormat/SwiftLint, `shellcheck scripts/*.sh`, and `scripts/build-release-artifact.sh 0.1.6 --adhoc` passed. Verified archive contents/checksum, both architectures, code signature, version output, and generated Homebrew formula syntax. The artifact was local validation only; no release was published.
- Codex autoreview completed with no actionable findings at its configured P0 threshold.

Fixes #51
