### PR TITLE
fix: return from withTimeout without joining uncooperative work

### DIFF
--- a/Sources/AXorcist/Core/AXTimeoutPolicy.swift
+++ b/Sources/AXorcist/Core/AXTimeoutPolicy.swift
@@ -195,25 +195,28 @@ public enum AXTimeoutHelper {
     ///
     /// Returns when `seconds` elapse even if `operation` ignores cancellation.
     /// The leftover work is asked to cancel but is not joined.
+    /// `operation` is `@concurrent` so `Thread.sleep` cannot hold MainActor
+    /// across the deadline under `defaultIsolation(MainActor.self)`.
     @MainActor
     public static func withTimeout<T: Sendable>(
         seconds: TimeInterval,
-        operation: @escaping @Sendable () async throws -> T) async throws -> T
+        operation: @escaping @concurrent @Sendable () async throws -> T) async throws -> T
     {
         try await self.race(seconds: seconds, operation: operation)
     }
 
     /// Race a deadline against unstructured work. A throwing TaskGroup would
     /// still join an uncooperative child after the timeout throw.
-    private nonisolated static func race<T: Sendable>(
+    @concurrent
+    private static func race<T: Sendable>(
         seconds: TimeInterval,
-        operation: @escaping @Sendable () async throws -> T) async throws -> T
+        operation: @escaping @concurrent @Sendable () async throws -> T) async throws -> T
     {
         let timeoutError = AXTimeoutError.operationTimedOut(duration: seconds)
-        let work = Task.detached {
+        let work = Task.detached { @concurrent in
             try await operation()
         }
-        let sleeper = Task.detached(priority: .utility) {
+        let sleeper = Task.detached(priority: .utility) { @concurrent in
             try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
         }
         let gateBox = OSAllocatedUnfairLock<FirstResultGate<Result<T, any Error>>?>(initialState: nil)
@@ -222,7 +225,7 @@ public enum AXTimeoutHelper {
             await withCheckedContinuation { continuation in
                 let gate = FirstResultGate(continuation: continuation)
                 gateBox.withLock { $0 = gate }
-                Task.detached {
+                Task.detached { @concurrent in
                     do {
                         let value = try await work.value
                         sleeper.cancel()
@@ -232,7 +235,7 @@ public enum AXTimeoutHelper {
                         gate.finish(with: .failure(error))
                     }
                 }
-                Task.detached {
+                Task.detached { @concurrent in
                     do {
                         try await sleeper.value
                     } catch {

--- a/Sources/AXorcist/Core/AXTimeoutPolicy.swift
+++ b/Sources/AXorcist/Core/AXTimeoutPolicy.swift
@@ -192,28 +192,63 @@ public struct AXTimeoutWrapper {
 public enum AXTimeoutHelper {
     /// Async timeout helper reused by downstreams (e.g., ScreenCaptureService)
     /// to keep timeout logic in one place.
+    ///
+    /// Returns when `seconds` elapse even if `operation` ignores cancellation.
+    /// The leftover work is asked to cancel but is not joined.
     @MainActor
     public static func withTimeout<T: Sendable>(
         seconds: TimeInterval,
         operation: @escaping @Sendable () async throws -> T) async throws -> T
     {
-        try await withThrowingTaskGroup(of: T.self) { group in
-            group.addTask {
-                try await operation()
-            }
+        try await self.race(seconds: seconds, operation: operation)
+    }
 
-            group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-                throw AXTimeoutError.operationTimedOut(duration: seconds)
-            }
-
-            guard let result = try await group.next() else {
-                throw AXTimeoutError.operationTimedOut(duration: seconds)
-            }
-
-            group.cancelAll()
-            return result
+    /// Race a deadline against unstructured work. A throwing TaskGroup would
+    /// still join an uncooperative child after the timeout throw.
+    private nonisolated static func race<T: Sendable>(
+        seconds: TimeInterval,
+        operation: @escaping @Sendable () async throws -> T) async throws -> T
+    {
+        let timeoutError = AXTimeoutError.operationTimedOut(duration: seconds)
+        let work = Task.detached {
+            try await operation()
         }
+        let sleeper = Task.detached(priority: .utility) {
+            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+        }
+        let gateBox = OSAllocatedUnfairLock<FirstResultGate<Result<T, any Error>>?>(initialState: nil)
+
+        let result: Result<T, any Error> = await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                let gate = FirstResultGate(continuation: continuation)
+                gateBox.withLock { $0 = gate }
+                Task.detached {
+                    do {
+                        let value = try await work.value
+                        sleeper.cancel()
+                        gate.finish(with: .success(value))
+                    } catch {
+                        sleeper.cancel()
+                        gate.finish(with: .failure(error))
+                    }
+                }
+                Task.detached {
+                    do {
+                        try await sleeper.value
+                    } catch {
+                        return
+                    }
+                    gate.finish(with: .failure(timeoutError), fromTimeout: true)
+                    work.cancel()
+                }
+            }
+        } onCancel: {
+            work.cancel()
+            sleeper.cancel()
+            gateBox.withLock { $0 }?.finish(with: .failure(CancellationError()), fromTimeout: true)
+        }
+
+        return try result.get()
     }
 }
 

--- a/Sources/AXorcist/Core/AXTimeoutPolicy.swift
+++ b/Sources/AXorcist/Core/AXTimeoutPolicy.swift
@@ -213,11 +213,8 @@ public enum AXTimeoutHelper {
         operation: @escaping @concurrent @Sendable () async throws -> T) async throws -> T
     {
         let timeoutError = AXTimeoutError.operationTimedOut(duration: seconds)
-        let work = Task.detached { @concurrent in
+        let work = Task.detached {
             try await operation()
-        }
-        let sleeper = Task.detached(priority: .utility) { @concurrent in
-            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
         }
         let gateBox = OSAllocatedUnfairLock<FirstResultGate<Result<T, any Error>>?>(initialState: nil)
 
@@ -225,29 +222,23 @@ public enum AXTimeoutHelper {
             await withCheckedContinuation { continuation in
                 let gate = FirstResultGate(continuation: continuation)
                 gateBox.withLock { $0 = gate }
-                Task.detached { @concurrent in
+                Task.detached {
                     do {
                         let value = try await work.value
-                        sleeper.cancel()
                         gate.finish(with: .success(value))
                     } catch {
-                        sleeper.cancel()
                         gate.finish(with: .failure(error))
                     }
                 }
-                Task.detached { @concurrent in
-                    do {
-                        try await sleeper.value
-                    } catch {
-                        return
-                    }
+                // GCD timer, not Task.sleep: CI Swift 6.2.1 serialized the
+                // sleeper Task behind the uncooperative work Task.
+                DispatchQueue.global().asyncAfter(deadline: .now() + seconds) {
                     gate.finish(with: .failure(timeoutError), fromTimeout: true)
                     work.cancel()
                 }
             }
         } onCancel: {
             work.cancel()
-            sleeper.cancel()
             gateBox.withLock { $0 }?.finish(with: .failure(CancellationError()), fromTimeout: true)
         }
 

--- a/Tests/AXorcistTests/AXTimeoutHelperTests.swift
+++ b/Tests/AXorcistTests/AXTimeoutHelperTests.swift
@@ -37,8 +37,6 @@ struct AXTimeoutHelperTests {
     @Test
     func `returns without joining uncooperative work`() async {
         let stillRunning = OSAllocatedUnfairLock(initialState: true)
-        let clock = ContinuousClock()
-        let started = clock.now
         do {
             _ = try await AXTimeoutHelper.withTimeout(seconds: 0.05) {
                 await Self.sleepIgnoringCancellation(2)
@@ -47,7 +45,8 @@ struct AXTimeoutHelperTests {
             }
             Issue.record("Expected timeout but succeeded")
         } catch is AXTimeoutError {
-            #expect(clock.now - started < .seconds(1))
+            // stillRunning is the join proof. Wall-clock bounds flake on
+            // CI when the full 213-test job delays the GCD deadline.
             #expect(stillRunning.withLock { $0 })
         } catch {
             Issue.record("Unexpected error: \(error)")

--- a/Tests/AXorcistTests/AXTimeoutHelperTests.swift
+++ b/Tests/AXorcistTests/AXTimeoutHelperTests.swift
@@ -39,7 +39,7 @@ struct AXTimeoutHelperTests {
         let stillRunning = OSAllocatedUnfairLock(initialState: true)
         do {
             _ = try await AXTimeoutHelper.withTimeout(seconds: 0.05) {
-                await Self.sleepIgnoringCancellation(2)
+                await Self.sleepIgnoringCancellation(30)
                 stillRunning.withLock { $0 = false }
                 return 1
             }

--- a/Tests/AXorcistTests/AXTimeoutHelperTests.swift
+++ b/Tests/AXorcistTests/AXTimeoutHelperTests.swift
@@ -1,6 +1,7 @@
 import ApplicationServices
 import Darwin
 import Foundation
+import os
 import Testing
 @testable import AXorcist
 
@@ -27,6 +28,24 @@ struct AXTimeoutHelperTests {
             Issue.record("Expected timeout but succeeded")
         } catch let error as AXTimeoutError {
             #expect(String(describing: error).contains("timed out"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @MainActor
+    @Test
+    func `returns without joining uncooperative work`() async {
+        let stillRunning = OSAllocatedUnfairLock(initialState: true)
+        do {
+            _ = try await AXTimeoutHelper.withTimeout(seconds: 0.05) {
+                Self.sleepIgnoringCancellation(2)
+                stillRunning.withLock { $0 = false }
+                return 1
+            }
+            Issue.record("Expected timeout but succeeded")
+        } catch is AXTimeoutError {
+            #expect(stillRunning.withLock { $0 })
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
@@ -238,5 +257,10 @@ struct AXTimeoutHelperTests {
                 }
             }
         }
+    }
+
+    /// Blocks the calling thread. Cancellation does not interrupt this wait.
+    private nonisolated static func sleepIgnoringCancellation(_ seconds: TimeInterval) {
+        Thread.sleep(forTimeInterval: seconds)
     }
 }

--- a/Tests/AXorcistTests/AXTimeoutHelperTests.swift
+++ b/Tests/AXorcistTests/AXTimeoutHelperTests.swift
@@ -41,7 +41,7 @@ struct AXTimeoutHelperTests {
         let started = clock.now
         do {
             _ = try await AXTimeoutHelper.withTimeout(seconds: 0.05) {
-                Self.sleepIgnoringCancellation(2)
+                await Self.sleepIgnoringCancellation(2)
                 stillRunning.withLock { $0 = false }
                 return 1
             }
@@ -262,8 +262,15 @@ struct AXTimeoutHelperTests {
         }
     }
 
-    /// Blocks the calling thread. Cancellation does not interrupt this wait.
-    private nonisolated static func sleepIgnoringCancellation(_ seconds: TimeInterval) {
-        Thread.sleep(forTimeInterval: seconds)
+    /// Blocks a background thread. Cancellation does not interrupt this wait.
+    /// Must not Thread.sleep on the caller: CI Swift 6.2.1 still runs the
+    /// `@Sendable` operation on MainActor, which would stall the deadline.
+    private nonisolated static func sleepIgnoringCancellation(_ seconds: TimeInterval) async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global().async {
+                Thread.sleep(forTimeInterval: seconds)
+                cont.resume()
+            }
+        }
     }
 }

--- a/Tests/AXorcistTests/AXTimeoutHelperTests.swift
+++ b/Tests/AXorcistTests/AXTimeoutHelperTests.swift
@@ -37,6 +37,8 @@ struct AXTimeoutHelperTests {
     @Test
     func `returns without joining uncooperative work`() async {
         let stillRunning = OSAllocatedUnfairLock(initialState: true)
+        let clock = ContinuousClock()
+        let started = clock.now
         do {
             _ = try await AXTimeoutHelper.withTimeout(seconds: 0.05) {
                 Self.sleepIgnoringCancellation(2)
@@ -45,6 +47,7 @@ struct AXTimeoutHelperTests {
             }
             Issue.record("Expected timeout but succeeded")
         } catch is AXTimeoutError {
+            #expect(clock.now - started < .seconds(1))
             #expect(stillRunning.withLock { $0 })
         } catch {
             Issue.record("Unexpected error: \(error)")


### PR DESCRIPTION
## What Problem This Solves

`AXTimeoutHelper.withTimeout` is the public async deadline helper used by
downstreams such as ScreenCaptureService. It raced the operation against
`Task.sleep` inside `withThrowingTaskGroup`. When the deadline threw, the
group still joined the operation child before the error reached the caller.

A cancellable `Task.sleep` hid that join. `Thread.sleep` and a stuck AX or
IO call ignore cancel, so the caller stayed blocked until that work
finished. A 50ms deadline wrapping a 2s uncooperative sleep returned after
2.005s, and the sleep had already completed.

This change races the deadline against detached work and returns when the
first result arrives. Timeout asks the child to cancel but does not join
it. Uncooperative AX work may continue in the background.

## Evidence

Same public call before and after:
`AXTimeoutHelper.withTimeout(seconds: 0.05)` wrapping a 2s uncooperative
thread sleep.

Before (TaskGroup join on current main):

```console
$ cd /tmp/ax-f003-before && swift run
RESULT=error Operation timed out after 0.05s
ELAPSED=2.005173708 seconds
STILL_RUNNING=false
```

After (this branch, live `swift run` against the patched AXorcist library):

```console
$ cd /tmp/ax-f003-proof && swift run
RESULT=error Operation timed out after 0.05s
ELAPSED=0.052286959 seconds
STILL_RUNNING=true
```

The patched helper returns at the 50ms deadline while the 2s sleep is
still running.

Related: introduced in 39e300e (2025-11-19). Nearby AX deadline work is
[#39](https://github.com/openclaw/AXorcist/pull/39),
[#45](https://github.com/openclaw/AXorcist/pull/45), and
[#47](https://github.com/openclaw/AXorcist/pull/47).

## Real behavior proof

- **Behavior or issue addressed:** Public `AXTimeoutHelper.withTimeout` returned only after uncooperative work finished, so a timeout did not bound `Thread.sleep` or a stuck AX/IO call.
- **Real environment tested:** macOS arm64, Apple Swift 6.3.3, AXorcist checkout `/tmp/oc-pr-AXorcist-F003` on `fix/f003-timeout-helper-return` from `openclaw/AXorcist` `d095c92`.
- **Exact steps or command run after this patch:** Built the patched library and ran `swift run` from `/tmp/ax-f003-proof`, which calls `AXTimeoutHelper.withTimeout(seconds: 0.05)` with a 2s uncooperative thread sleep.
- **Evidence after fix:** terminal output from the patched library:

  ```console
  $ cd /tmp/ax-f003-proof && swift run
  RESULT=error Operation timed out after 0.05s
  ELAPSED=0.052286959 seconds
  STILL_RUNNING=true
  ```

- **Observed result after fix:** The call returned `Operation timed out after 0.05s` in 0.052s while the sleep was still running (`STILL_RUNNING=true`). The same public call against the old TaskGroup path took 2.005s and the sleep had already finished.
- **What was not tested:** Live ScreenCaptureService and a wedged `AXUIElement` IPC call. Native AX messaging deadlines remain `withMessagingTimeout`.
