### PR TITLE
fix: apply a real deadline in AXTimeoutWrapper.execute

### DIFF
--- a/Sources/AXorcist/Core/AXTimeoutPolicy.swift
+++ b/Sources/AXorcist/Core/AXTimeoutPolicy.swift
@@ -111,6 +111,7 @@ private enum AXMessagingTimeoutRegistry {
 enum AXMessagingTimeoutScope {
     static func perform<Value>(
         timeout: Float,
+        resetTo: Float = 0,
         applyTimeout: (Float) -> AXError,
         operation: () throws -> Value) throws -> Value
     {
@@ -126,7 +127,7 @@ enum AXMessagingTimeoutScope {
         let operationResult: Result<Value, any Error> = Result {
             try operation()
         }
-        let resetResult = applyTimeout(0)
+        let resetResult = applyTimeout(resetTo)
         guard resetResult == .success else {
             throw AXMessagingTimeoutError.resetFailure(code: resetResult.rawValue)
         }
@@ -136,6 +137,13 @@ enum AXMessagingTimeoutScope {
 
 /// Global timeout configuration for all AX operations.
 public enum AXTimeoutConfiguration {
+    /// Last value successfully installed by `setGlobalTimeout`.
+    ///
+    /// `0` means macOS default. `AXTimeoutWrapper.execute` restores this
+    /// after a temporary system-wide deadline so a prior global bound survives.
+    @MainActor
+    static var installedTimeout: Float = 0
+
     /// Set the global messaging timeout for all AX operations.
     @MainActor
     public static func setGlobalTimeout(_ timeout: Float) {
@@ -145,6 +153,7 @@ public enum AXTimeoutConfiguration {
         if error != .success {
             logger.warning("Failed to set global AX timeout: \(error.rawValue)")
         } else {
+            self.installedTimeout = timeout
             logger.info("Set global AX timeout to \(timeout, format: .fixed(precision: 2)) seconds")
         }
     }
@@ -181,6 +190,7 @@ public struct AXTimeoutWrapper {
             do {
                 if let result = try AXMessagingTimeoutScope.perform(
                     timeout: self.timeout,
+                    resetTo: AXTimeoutConfiguration.installedTimeout,
                     applyTimeout: applyTimeout,
                     operation: operation)
                 {

--- a/Sources/AXorcist/Core/AXTimeoutPolicy.swift
+++ b/Sources/AXorcist/Core/AXTimeoutPolicy.swift
@@ -154,22 +154,40 @@ public enum AXTimeoutConfiguration {
 public struct AXTimeoutWrapper {
     private let maxRetries: Int
     private let retryDelay: TimeInterval
+    private let timeout: Float
 
-    public init(maxRetries: Int = 3, retryDelay: TimeInterval = 0.5) {
+    public init(maxRetries: Int = 3, retryDelay: TimeInterval = 0.5, timeout: Float = 2.0) {
         self.maxRetries = maxRetries
         self.retryDelay = retryDelay
+        self.timeout = timeout
     }
 
-    /// Execute an AX operation with timeout protection and retry logic.
+    /// Execute an AX operation with a system-wide messaging deadline and retry on throw.
     @MainActor
     public func execute<T>(_ operation: () throws -> T?) async throws -> T? {
+        try await self.execute(
+            applyTimeout: { AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide(), $0) },
+            operation: operation)
+    }
+
+    @MainActor
+    func execute<T>(
+        applyTimeout: (Float) -> AXError,
+        operation: () throws -> T?) async throws -> T?
+    {
         var lastError: (any Error)?
 
         for attempt in 0..<self.maxRetries {
             do {
-                if let result = try operation() {
+                if let result = try AXMessagingTimeoutScope.perform(
+                    timeout: self.timeout,
+                    applyTimeout: applyTimeout,
+                    operation: operation)
+                {
                     return result
                 }
+            } catch let error as AXMessagingTimeoutError {
+                throw error
             } catch {
                 lastError = error
                 Logger(subsystem: "boo.peekaboo.axorcist", category: "AXTimeout")

--- a/Tests/AXorcistTests/AXTimeoutHelperTests.swift
+++ b/Tests/AXorcistTests/AXTimeoutHelperTests.swift
@@ -259,6 +259,27 @@ struct AXTimeoutHelperTests {
 
     @Test
     @MainActor
+    func `timeout wrapper restores a previous global deadline instead of zero`() async throws {
+        let previous = AXTimeoutConfiguration.installedTimeout
+        AXTimeoutConfiguration.installedTimeout = 3.0
+        defer { AXTimeoutConfiguration.installedTimeout = previous }
+
+        var timeoutHistory: [Float] = []
+        let wrapper = AXTimeoutWrapper(maxRetries: 1, retryDelay: 0, timeout: 0.5)
+
+        let result = try await wrapper.execute(
+            applyTimeout: { timeout in
+                timeoutHistory.append(timeout)
+                return .success
+            },
+            operation: { 42 })
+
+        #expect(result == 42)
+        #expect(timeoutHistory == [0.5, 3.0])
+    }
+
+    @Test
+    @MainActor
     func `timeout wrapper skips the operation when the deadline cannot be armed`() async {
         var armAttempts = 0
         var dispatched = 0

--- a/Tests/AXorcistTests/AXTimeoutHelperTests.swift
+++ b/Tests/AXorcistTests/AXTimeoutHelperTests.swift
@@ -239,4 +239,150 @@ struct AXTimeoutHelperTests {
             }
         }
     }
+
+    @Test
+    @MainActor
+    func `timeout wrapper arms and clears the messaging deadline`() async throws {
+        var timeoutHistory: [Float] = []
+        let wrapper = AXTimeoutWrapper(maxRetries: 1, retryDelay: 0, timeout: 0.5)
+
+        let result = try await wrapper.execute(
+            applyTimeout: { timeout in
+                timeoutHistory.append(timeout)
+                return .success
+            },
+            operation: { 42 })
+
+        #expect(result == 42)
+        #expect(timeoutHistory == [0.5, 0])
+    }
+
+    @Test
+    @MainActor
+    func `timeout wrapper skips the operation when the deadline cannot be armed`() async {
+        var armAttempts = 0
+        var dispatched = 0
+        let wrapper = AXTimeoutWrapper(maxRetries: 3, retryDelay: 0, timeout: 0.25)
+
+        do {
+            _ = try await wrapper.execute(
+                applyTimeout: { _ in
+                    armAttempts += 1
+                    return .failure
+                },
+                operation: { () -> Int? in
+                    dispatched += 1
+                    return 1
+                })
+            Issue.record("Expected systemFailure")
+        } catch let error as AXMessagingTimeoutError {
+            #expect(error == .systemFailure(code: AXError.failure.rawValue))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(armAttempts == 1)
+        #expect(dispatched == 0)
+    }
+
+    @Test
+    @MainActor
+    func `timeout wrapper retries a thrown operation with a fresh deadline`() async throws {
+        enum ProbeError: Error {
+            case failed
+        }
+
+        var timeoutHistory: [Float] = []
+        var attempts = 0
+        let wrapper = AXTimeoutWrapper(maxRetries: 2, retryDelay: 0, timeout: 0.25)
+
+        let result = try await wrapper.execute(
+            applyTimeout: { timeout in
+                timeoutHistory.append(timeout)
+                return .success
+            },
+            operation: { () -> Int? in
+                attempts += 1
+                if attempts == 1 {
+                    throw ProbeError.failed
+                }
+                return 7
+            })
+
+        #expect(result == 7)
+        #expect(attempts == 2)
+        #expect(timeoutHistory == [0.25, 0, 0.25, 0])
+    }
+
+    @Test
+    @MainActor
+    func `timeout wrapper does not retry a reset failure`() async {
+        var armAttempts = 0
+        let wrapper = AXTimeoutWrapper(maxRetries: 3, retryDelay: 0, timeout: 0.25)
+
+        do {
+            _ = try await wrapper.execute(
+                applyTimeout: { timeout in
+                    armAttempts += 1
+                    return timeout == 0 ? .failure : .success
+                },
+                operation: { 42 })
+            Issue.record("Expected resetFailure")
+        } catch let error as AXMessagingTimeoutError {
+            #expect(error == .resetFailure(code: AXError.failure.rawValue))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(armAttempts == 2)
+    }
+
+    @Test(arguments: [Float.zero, -0.1, -.infinity, .infinity, .nan])
+    @MainActor
+    func `timeout wrapper rejects invalid deadlines before the system call`(timeout: Float) async {
+        var appliedTimeouts: [Float] = []
+        var dispatched = false
+        let wrapper = AXTimeoutWrapper(maxRetries: 1, retryDelay: 0, timeout: timeout)
+
+        do {
+            _ = try await wrapper.execute(
+                applyTimeout: { value in
+                    appliedTimeouts.append(value)
+                    return .success
+                },
+                operation: { () -> Int? in
+                    dispatched = true
+                    return 1
+                })
+            Issue.record("Expected invalidTimeout")
+        } catch let error as AXMessagingTimeoutError {
+            #expect(error == .invalidTimeout)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(appliedTimeouts.isEmpty)
+        #expect(!dispatched)
+    }
+
+    @Test
+    @MainActor
+    func `timeout wrapper execute rejects a zero deadline before running the operation`() async {
+        var dispatched = false
+        let wrapper = AXTimeoutWrapper(maxRetries: 1, retryDelay: 0, timeout: 0)
+
+        do {
+            _ = try await wrapper.execute { () -> Int? in
+                dispatched = true
+                return 1
+            }
+            Issue.record("Expected invalidTimeout")
+        } catch let error as AXMessagingTimeoutError {
+            #expect(error == .invalidTimeout)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(!dispatched)
+    }
 }


### PR DESCRIPTION
## What Problem This Solves

`AXTimeoutWrapper.execute` is a public `@MainActor` helper whose docs claim
timeout protection. It only retried a thrown closure. It never armed
`AXUIElementSetMessagingTimeout` or any other deadline.

Callers such as `try await AXTimeoutWrapper().execute { element.windows() }`
therefore ran a synchronous AX read with no IPC bound. A wedged element
holds the MainActor for the life of that call. Nearby `withMessagingTimeout`
already fail-closes when a deadline cannot be armed. This wrapper was not
migrated.

This change adds a `timeout` (default 2.0s) and arms a system-wide
messaging deadline around each attempt. Setup and reset failures throw
immediately. Thrown AX work still retries with a fresh deadline. After each attempt the wrapper restores the last `AXTimeoutConfiguration.setGlobalTimeout` value instead of writing 0, so a process-wide bound survives the call.

## Evidence

Same public `AXTimeoutWrapper.execute` call before and after.

Before (`openclaw/AXorcist` `d095c92`, no deadline exists):

```console
$ cd /tmp/ax-f004-before && swift run
RESULT=ran
DISPATCHED=true
```

After (this branch, live `swift run` against the patched AXorcist library).
A zero deadline is rejected before the closure runs. A 0.25s deadline
returns the value and a `windows()` read without hanging:

```console
$ cd /tmp/ax-f004-proof && swift run
ZERO_RESULT=error AX messaging timeout must be finite and greater than zero.
ZERO_DISPATCHED=false
VALUE_RESULT=42
WINDOWS_RESULT=nil
WINDOWS_ELAPSED=0.0021675 seconds
```

Related: introduced in 89cbe7a (2025-11-19). Nearby AX deadline work is
[#39](https://github.com/openclaw/AXorcist/pull/39),
[#45](https://github.com/openclaw/AXorcist/pull/45), and
[#47](https://github.com/openclaw/AXorcist/pull/47). Sibling helper
[#54](https://github.com/openclaw/AXorcist/pull/54) bounds
`AXTimeoutHelper.withTimeout` and does not change this wrapper.

## Real behavior proof

- **Behavior or issue addressed:** Public `AXTimeoutWrapper.execute` claimed timeout protection but ran the synchronous AX closure with no `AXUIElementSetMessagingTimeout` deadline, so a wedged `element.windows()` could hang the MainActor.
- **Real environment tested:** macOS 26.6.2 arm64, Apple Swift 6.3.3, AXorcist checkout `/tmp/oc-pr-AXorcist-F004` on `fix/f004-timeout-wrapper-deadline` from `openclaw/AXorcist` `d095c92`.
- **Exact steps or command run after this patch:** Built the patched library and ran `swift run` from `/tmp/ax-f004-proof`, which calls public `AXTimeoutWrapper.execute` with a zero deadline, then with a 0.25s deadline around a constant and `Element.windows()`.
- **Evidence after fix:** terminal output from the patched library:

  ```console
  $ cd /tmp/ax-f004-proof && swift run
  ZERO_RESULT=error AX messaging timeout must be finite and greater than zero.
  ZERO_DISPATCHED=false
  VALUE_RESULT=42
  WINDOWS_RESULT=nil
  WINDOWS_ELAPSED=0.0021675 seconds
  ```

- **Observed result after fix:** A zero deadline throws `AX messaging timeout must be finite and greater than zero` and the closure does not run (`ZERO_DISPATCHED=false`). The same public call on `d095c92` always ran the closure (`RESULT=ran`, `DISPATCHED=true`). A 0.25s deadline returns `42` and finishes `windows()` in 0.002s.
- **What was not tested:** A wedged `AXUIElement` IPC hang. Per-element `withMessagingTimeout` is unchanged. Native timeout enforcement is still macOS `AXUIElementSetMessagingTimeout`.

