### PR TITLE
fix(observer): defer workspace lifecycle reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to AXorcist will be documented in this file.
 
 ### Fixed
 - Keep Commander pinned to the remote exact 0.2.4 release regardless of checkout or scratch path; use explicit workspace overrides for local development.
+- Avoid synchronous LaunchServices termination queries during global application monitoring, and defer lifecycle callbacks out of KVO while preserving application identity, readiness, and stop/restart safety.
 
 ## [0.1.7] - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -524,6 +524,10 @@ let watcher = NotificationWatcher(globalNotification: .focusedUIElementChanged) 
 try watcher.start()
 ```
 
+Workspace snapshots are reconciled after the KVO callback returns. Membership in `runningApplications` supplies
+termination state without querying every application's `isTerminated` property; queued callbacks are discarded when
+the watcher stops, including across a restart.
+
 Applications that do not support the requested notification are skipped. Starting installs lifecycle tracking and
 returns without waiting for per-application Accessibility endpoints; observer creation, registration, and cleanup run
 off the main actor with bounded native messaging timeouts, so one wedged app cannot block startup or teardown. The

--- a/Sources/AXorcist/Core/AXGlobalApplicationMonitor.swift
+++ b/Sources/AXorcist/Core/AXGlobalApplicationMonitor.swift
@@ -17,28 +17,46 @@ protocol AXGlobalApplicationMonitoring: AnyObject, Sendable {
 /// lifecycle events needed to attach and detach those observers without polling.
 @MainActor
 final class AXWorkspaceApplicationMonitor: AXGlobalApplicationMonitoring {
+    convenience init() {
+        self.init(workspace: NSWorkspace.shared, runningApplications: \.runningApplications)
+    }
+
+    init<Workspace: NSObject>(
+        workspace: Workspace,
+        runningApplications: any KeyPath<Workspace, [NSRunningApplication]> & Sendable)
+    {
+        self.observeRunningApplications = { handler in
+            workspace.observe(runningApplications, options: [.initial]) { workspace, _ in
+                // Indexed KVO changes can contain only the changed entries. Capture the full
+                // membership snapshot here, without reading any application metadata.
+                handler(workspace[keyPath: runningApplications])
+            }
+        }
+    }
+
     var runningProcessIdentifiers: [pid_t] {
-        Self.eligibleApplications(NSWorkspace.shared.runningApplications).map(\.processIdentifier)
+        Array(self.applicationsByIdentity.values)
     }
 
     func start(
         onLaunch: @escaping @MainActor (pid_t) -> Void,
         onTermination: @escaping @MainActor (pid_t) -> Void)
     {
-        guard self.runningApplicationsObservation == nil else { return }
+        guard self.sessionID == nil else { return }
+        let sessionID = UUID()
+        self.sessionID = sessionID
         self.onLaunch = onLaunch
         self.onTermination = onTermination
-        self.runningApplicationsObservation = NSWorkspace.shared.observe(
-            \.runningApplications,
-            options: [.initial, .new])
-        { [weak self] _, _ in
-            MainActor.assumeIsolated {
-                self?.reconcile(NSWorkspace.shared.runningApplications)
+        self.runningApplicationsObservation = self.observeRunningApplications { [weak self] applications in
+            DispatchQueue.main.async { [weak self] in
+                guard let self, self.sessionID == sessionID else { return }
+                self.reconcile(applications, sessionID: sessionID)
             }
         }
     }
 
     func stop() {
+        self.sessionID = nil
         self.runningApplicationsObservation?.invalidate()
         self.runningApplicationsObservation = nil
         for observation in self.readinessObservations.values {
@@ -50,6 +68,9 @@ final class AXWorkspaceApplicationMonitor: AXGlobalApplicationMonitoring {
         self.onTermination = nil
     }
 
+    private let observeRunningApplications:
+        (@escaping @Sendable ([NSRunningApplication]) -> Void) -> NSKeyValueObservation
+    private var sessionID: UUID?
     private var runningApplicationsObservation: NSKeyValueObservation?
     private var readinessObservations: [NSRunningApplication: NSKeyValueObservation] = [:]
     // Retain AppKit's semantic application keys: separate wrappers for one process instance
@@ -58,11 +79,16 @@ final class AXWorkspaceApplicationMonitor: AXGlobalApplicationMonitoring {
     private var onLaunch: (@MainActor (pid_t) -> Void)?
     private var onTermination: (@MainActor (pid_t) -> Void)?
 
-    private func reconcile(_ runningApplications: [NSRunningApplication]) {
-        let currentApplications = Dictionary(
-            uniqueKeysWithValues: Self.eligibleApplications(runningApplications).map {
-                ($0, $0.processIdentifier)
-            })
+    private func reconcile(_ runningApplications: [NSRunningApplication], sessionID: UUID) {
+        // Workspace membership already identifies running apps. Querying isTerminated
+        // for each entry can synchronously block on LaunchServices.
+        let currentApplications = runningApplications
+            .reduce(into: [NSRunningApplication: pid_t]()) { applications, app in
+                let processIdentifier = app.processIdentifier
+                if processIdentifier > 0 {
+                    applications[app] = processIdentifier
+                }
+            }
         let changes = Self.lifecycleChanges(
             previous: self.applicationsByIdentity,
             current: currentApplications)
@@ -71,40 +97,45 @@ final class AXWorkspaceApplicationMonitor: AXGlobalApplicationMonitoring {
         for application in removedApplications {
             self.readinessObservations.removeValue(forKey: application)?.invalidate()
         }
+        self.applicationsByIdentity = currentApplications
         for processIdentifier in changes.terminations {
+            guard self.sessionID == sessionID else { return }
             self.onTermination?(processIdentifier)
         }
-        self.applicationsByIdentity = currentApplications
         for application in addedApplications {
-            self.observeReadiness(of: application)
+            guard self.sessionID == sessionID else { return }
+            self.observeReadiness(of: application, sessionID: sessionID)
         }
         for processIdentifier in changes.launches {
+            guard self.sessionID == sessionID else { return }
             self.onLaunch?(processIdentifier)
         }
     }
 
-    private func observeReadiness(of application: NSRunningApplication) {
+    private func observeReadiness(of application: NSRunningApplication, sessionID: UUID) {
         guard !application.isFinishedLaunching else { return }
         let observation = application.observe(\.isFinishedLaunching, options: [.new]) { [weak self] app, change in
             guard change.newValue == true else { return }
-            MainActor.assumeIsolated {
-                self?.applicationBecameReady(app)
+            DispatchQueue.main.async { [weak self] in
+                self?.applicationBecameReady(app, sessionID: sessionID)
             }
         }
         self.readinessObservations[application] = observation
         if application.isFinishedLaunching {
-            self.applicationBecameReady(application)
+            self.applicationBecameReady(application, sessionID: sessionID)
         }
     }
 
-    private func applicationBecameReady(_ application: NSRunningApplication) {
-        guard let observation = Self.claimReadiness(
-            for: application,
-            activeApplications: Set(self.applicationsByIdentity.keys),
-            observations: &self.readinessObservations)
+    private func applicationBecameReady(_ application: NSRunningApplication, sessionID: UUID) {
+        guard self.sessionID == sessionID,
+              let processIdentifier = self.applicationsByIdentity[application],
+              let observation = Self.claimReadiness(
+                  for: application,
+                  activeApplications: Set(self.applicationsByIdentity.keys),
+                  observations: &self.readinessObservations)
         else { return }
         observation.invalidate()
-        self.onLaunch?(application.processIdentifier)
+        self.onLaunch?(processIdentifier)
     }
 
     static func claimReadiness<Identity: Hashable, Observation>(
@@ -127,11 +158,5 @@ final class AXWorkspaceApplicationMonitor: AXGlobalApplicationMonitoring {
             previous[identity] == nil ? processIdentifier : nil
         }.sorted()
         return (terminations, launches)
-    }
-
-    private static func eligibleApplications(
-        _ runningApplications: [NSRunningApplication]) -> [NSRunningApplication]
-    {
-        runningApplications.filter { !$0.isTerminated && $0.processIdentifier > 0 }
     }
 }

--- a/Tests/AXorcistTests/WorkspaceApplicationMonitorTests.swift
+++ b/Tests/AXorcistTests/WorkspaceApplicationMonitorTests.swift
@@ -1,0 +1,326 @@
+import AppKit
+import Foundation
+import Testing
+@testable import AXorcist
+
+@Suite("Workspace application monitor")
+@MainActor
+struct WorkspaceApplicationMonitorTests {
+    @Test(.timeLimit(.minutes(1)))
+    func `global watcher registers the deferred initial snapshot once before backoff`() async throws {
+        let probe = ApplicationMetadataProbe()
+        let application = MonitorApplication(instance: "initial", pid: 42, probe: probe)
+        let workspace = MonitorWorkspace(applications: [application])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        let (attempts, continuation) = AsyncStream<pid_t>.makeStream()
+        let registry = MonitorRegistry(attempts: continuation)
+        let watcher = NotificationWatcher(
+            globalNotification: .focusedUIElementChanged,
+            registry: registry,
+            applicationMonitor: monitor,
+            retrySleep: { _ in try await Task.sleep(for: .seconds(60)) },
+            handler: { _, _, _, _ in })
+        defer { watcher.stop() }
+
+        try watcher.start()
+        #expect(watcher.isActive)
+        var iterator = attempts.makeAsyncIterator()
+        #expect(await iterator.next() == 42)
+        await drainMainQueue()
+
+        #expect(registry.processIdentifiers == [42])
+        #expect(monitor.runningProcessIdentifiers == [42])
+    }
+
+    @Test
+    func `lifecycle delivery never queries termination or reads application metadata inside KVO`() async {
+        let probe = ApplicationMetadataProbe()
+        let application = MonitorApplication(instance: "first", pid: 42, probe: probe)
+        let workspace = MonitorWorkspace(applications: [application])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        var events: [String] = []
+
+        probe.insideCallback = true
+        monitor.start(onLaunch: { events.append("launch:\($0)") }, onTermination: { events.append("terminate:\($0)") })
+        probe.insideCallback = false
+        await drainMainQueue()
+        #expect(monitor.runningProcessIdentifiers == [42])
+
+        probe.insideCallback = true
+        workspace.applications = []
+        probe.insideCallback = false
+        await drainMainQueue()
+
+        #expect(events == ["launch:42", "terminate:42"])
+        #expect(monitor.runningProcessIdentifiers.isEmpty)
+        #expect(probe.terminationReads == 0)
+        #expect(probe.reentrantMetadataReads == 0)
+        monitor.stop()
+    }
+
+    @Test
+    func `queued snapshots preserve intermediate termination and semantic PID reuse`() async {
+        let probe = ApplicationMetadataProbe()
+        let original = MonitorApplication(instance: "original", pid: 42, probe: probe)
+        let equalWrapper = MonitorApplication(instance: "original", pid: 42, probe: probe)
+        let replacement = MonitorApplication(instance: "replacement", pid: 42, probe: probe)
+        let workspace = MonitorWorkspace(applications: [original])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        var events: [String] = []
+        monitor.start(onLaunch: { events.append("launch:\($0)") }, onTermination: { events.append("terminate:\($0)") })
+        workspace.applications = [equalWrapper]
+        workspace.applications = []
+        workspace.applications = [replacement]
+        await drainMainQueue()
+
+        #expect(events == ["launch:42", "terminate:42", "launch:42"])
+        #expect(monitor.runningProcessIdentifiers == [42])
+        monitor.stop()
+    }
+
+    @Test
+    func `indexed workspace changes retain unchanged applications and reject invalid PIDs`() async {
+        let probe = ApplicationMetadataProbe()
+        let original = MonitorApplication(instance: "original", pid: 41, probe: probe)
+        let added = MonitorApplication(instance: "added", pid: 42, probe: probe)
+        let workspace = MonitorWorkspace(applications: [original])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        var events: [String] = []
+        monitor.start(onLaunch: { events.append("launch:\($0)") }, onTermination: { events.append("terminate:\($0)") })
+        let applications = workspace.mutableArrayValue(forKey: #keyPath(MonitorWorkspace.applications))
+        applications.add(added)
+        applications.add(MonitorApplication(instance: "no-pid", pid: -1, probe: probe))
+        applications.add(MonitorApplication(instance: "zero", pid: 0, probe: probe))
+        await drainMainQueue()
+
+        #expect(events == ["launch:41", "launch:42"])
+        #expect(monitor.runningProcessIdentifiers.sorted() == [41, 42])
+        applications.removeObject(at: 0)
+        await drainMainQueue()
+
+        #expect(events == ["launch:41", "launch:42", "terminate:41"])
+        #expect(monitor.runningProcessIdentifiers == [42])
+        monitor.stop()
+    }
+
+    @Test
+    func `stop and restart reject queued lifecycle snapshots from the previous session`() async {
+        let probe = ApplicationMetadataProbe()
+        let previous = MonitorApplication(instance: "previous", pid: 41, probe: probe)
+        let replacement = MonitorApplication(instance: "replacement", pid: 42, probe: probe)
+        let workspace = MonitorWorkspace(applications: [previous])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        var stoppedEvents: [pid_t] = []
+        var currentEvents: [String] = []
+        monitor.start(onLaunch: { stoppedEvents.append($0) }, onTermination: { stoppedEvents.append($0) })
+        monitor.stop()
+        workspace.applications = [replacement]
+        monitor.start(
+            onLaunch: { currentEvents.append("launch:\($0)") },
+            onTermination: { currentEvents.append("terminate:\($0)") })
+        await drainMainQueue()
+
+        #expect(stoppedEvents.isEmpty)
+        #expect(currentEvents == ["launch:42"])
+        #expect(monitor.runningProcessIdentifiers == [42])
+        monitor.stop()
+    }
+
+    @Test
+    func `readiness transition retries once without reentering KVO`() async {
+        let probe = ApplicationMetadataProbe()
+        let application = MonitorApplication(instance: "slow", pid: 42, ready: false, probe: probe)
+        let workspace = MonitorWorkspace(applications: [application])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        var launches: [pid_t] = []
+        var reentrantLaunches = 0
+        monitor.start(onLaunch: {
+            launches.append($0)
+            if probe.insideCallback {
+                reentrantLaunches += 1
+            }
+        }, onTermination: { _ in })
+        await drainMainQueue()
+        #expect(launches == [42])
+
+        probe.insideCallback = true
+        application.finishLaunching()
+        application.finishLaunching()
+        probe.insideCallback = false
+        await drainMainQueue()
+
+        #expect(launches == [42, 42])
+        #expect(reentrantLaunches == 0)
+        monitor.stop()
+    }
+
+    @Test
+    func `queued readiness cannot revive an observation after stop and restart`() async {
+        let probe = ApplicationMetadataProbe()
+        let application = MonitorApplication(instance: "slow", pid: 42, ready: false, probe: probe)
+        let workspace = MonitorWorkspace(applications: [application])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        var oldLaunches: [pid_t] = []
+        var newLaunches: [pid_t] = []
+        monitor.start(onLaunch: { oldLaunches.append($0) }, onTermination: { _ in })
+        await drainMainQueue()
+        application.finishLaunching()
+        monitor.stop()
+        monitor.start(onLaunch: { newLaunches.append($0) }, onTermination: { _ in })
+        await drainMainQueue()
+
+        #expect(oldLaunches == [42])
+        #expect(newLaunches == [42])
+        monitor.stop()
+    }
+
+    @Test
+    func `termination discards a queued readiness callback`() async {
+        let probe = ApplicationMetadataProbe()
+        let application = MonitorApplication(instance: "slow", pid: 42, ready: false, probe: probe)
+        let workspace = MonitorWorkspace(applications: [application])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        var events: [String] = []
+        monitor.start(onLaunch: { events.append("launch:\($0)") }, onTermination: { events.append("terminate:\($0)") })
+        await drainMainQueue()
+        workspace.applications = []
+        application.finishLaunching()
+        await drainMainQueue()
+
+        #expect(events == ["launch:42", "terminate:42"])
+        #expect(monitor.runningProcessIdentifiers.isEmpty)
+        monitor.stop()
+    }
+
+    @Test
+    func `stopping from a lifecycle handler prevents remaining callbacks`() async {
+        let probe = ApplicationMetadataProbe()
+        let workspace = MonitorWorkspace(applications: [
+            MonitorApplication(instance: "first", pid: 41, probe: probe),
+            MonitorApplication(instance: "second", pid: 42, probe: probe),
+        ])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        var launches: [pid_t] = []
+        monitor.start(onLaunch: {
+            launches.append($0)
+            monitor.stop()
+        }, onTermination: { _ in })
+        await drainMainQueue()
+
+        #expect(launches == [41])
+        #expect(monitor.runningProcessIdentifiers.isEmpty)
+    }
+}
+
+@MainActor
+private func drainMainQueue() async {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.main.async { continuation.resume() }
+    }
+}
+
+@MainActor
+private final class ApplicationMetadataProbe {
+    var insideCallback = false
+    var terminationReads = 0
+    var reentrantMetadataReads = 0
+
+    func recordRead() {
+        if self.insideCallback {
+            self.reentrantMetadataReads += 1
+        }
+    }
+}
+
+@MainActor
+private final class MonitorRegistry: AXObservationRegistry {
+    let attempts: AsyncStream<pid_t>.Continuation
+    var processIdentifiers: [pid_t] = []
+
+    init(attempts: AsyncStream<pid_t>.Continuation) {
+        self.attempts = attempts
+    }
+
+    func subscribeProcess(
+        pid: pid_t,
+        element: Element?,
+        notification: AXNotification,
+        handler: @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
+    {
+        self.processIdentifiers.append(pid)
+        self.attempts.yield(pid)
+        return .failure(.observerSetupFailed(details: "Synthetic registration failure"))
+    }
+
+    func unsubscribe(token: SubscriptionToken) throws {}
+}
+
+@MainActor
+private final class MonitorWorkspace: NSObject {
+    private var storedApplications: [NSRunningApplication]
+
+    @objc dynamic nonisolated var applications: [NSRunningApplication] {
+        get { MainActor.assumeIsolated { self.storedApplications } }
+        set { MainActor.assumeIsolated { self.storedApplications = newValue } }
+    }
+
+    @MainActor
+    init(applications: [NSRunningApplication]) {
+        self.storedApplications = applications
+        super.init()
+    }
+}
+
+private final nonisolated class MonitorApplication: NSRunningApplication, @unchecked Sendable {
+    private let instance: String
+    private let pid: pid_t
+    private let probe: ApplicationMetadataProbe
+    @MainActor private var ready: Bool
+
+    @MainActor
+    init(instance: String, pid: pid_t, ready: Bool = true, probe: ApplicationMetadataProbe) {
+        self.instance = instance
+        self.pid = pid
+        self.ready = ready
+        self.probe = probe
+        super.init()
+    }
+
+    override var processIdentifier: pid_t {
+        MainActor.assumeIsolated {
+            self.probe.recordRead()
+            return self.pid
+        }
+    }
+
+    override var isTerminated: Bool {
+        MainActor.assumeIsolated {
+            self.probe.recordRead()
+            self.probe.terminationReads += 1
+            return false
+        }
+    }
+
+    override var isFinishedLaunching: Bool {
+        MainActor.assumeIsolated {
+            self.probe.recordRead()
+            return self.ready
+        }
+    }
+
+    @MainActor
+    func finishLaunching() {
+        let key = #keyPath(NSRunningApplication.isFinishedLaunching)
+        self.willChangeValue(forKey: key)
+        self.ready = true
+        self.didChangeValue(forKey: key)
+    }
+
+    override var hash: Int {
+        self.instance.hashValue
+    }
+
+    override func isEqual(_ object: Any?) -> Bool {
+        (object as? MonitorApplication)?.instance == self.instance
+    }
+}


### PR DESCRIPTION
## Summary

Avoid synchronous LaunchServices termination queries in global application monitoring. Signed native profiling during Peekaboo release testing identified `NSRunningApplication.isTerminated` calls from the workspace KVO callback occupying the daemon's main thread. The sample identifies this blocking owner; it does not establish the cause of every earlier timeout.

Use `runningApplications` membership as the lifecycle authority, capture complete workspace snapshots, and reconcile them after the KVO callback returns. Keep semantic application identity, intermediate termination/replacement events, launch-readiness observation, and positive-PID filtering. Session guards discard queued work after stop/restart and stop remaining callbacks when a handler stops the monitor.

## Validation

- Nine new inert tests exercise actual Foundation KVO with synthetic application objects, plus 15 existing observer-lifecycle tests: **24 passed**, independently rerun.
- The original monitor behavior with only the fixture adapter fails the termination-query and reentrant-readiness checks. Additional tests protect the stop/restart safety required by deferred delivery, indexed KVO changes, PID reuse, and real `NotificationWatcher` startup.
- Focused SwiftFormat, strict SwiftLint, and `git diff --check` passed. Independent Codex autoreview was scoped-clean at its configured P0 threshold.

Local focused proof used Xcode 27 / Swift 6.4 with SwiftPM's native build engine after the default engine stalled during SDK-stat-cache preparation. The native-engine flag emits a deprecation warning; this is not a warning-free publication-build claim. Normal upstream CI and subsequent signed Peekaboo native retesting remain required. No version or artifact publication is included.
