### PR TITLE
fix(observer): isolate workspace metadata reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to AXorcist will be documented in this file.
 ### Fixed
 - Keep Commander pinned to the remote exact 0.2.4 release regardless of checkout or scratch path; use explicit workspace overrides for local development.
 - Keep global application PID and launch-readiness reads off the main actor and outside KVO callbacks, use workspace membership instead of termination queries, and discard stale metadata across stop, restart, and application replacement.
+- Retain each exact application wrapper until its readiness observation finishes unregistering, preventing premature deallocation during queued cleanup and semantic wrapper replacement.
 
 ## [0.1.7] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to AXorcist will be documented in this file.
 
 ### Fixed
 - Keep Commander pinned to the remote exact 0.2.4 release regardless of checkout or scratch path; use explicit workspace overrides for local development.
-- Avoid synchronous LaunchServices termination queries during global application monitoring, and defer lifecycle callbacks out of KVO while preserving application identity, readiness, and stop/restart safety.
+- Keep global application PID and launch-readiness reads off the main actor and outside KVO callbacks, use workspace membership instead of termination queries, and discard stale metadata across stop, restart, and application replacement.
 
 ## [0.1.7] - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -524,9 +524,11 @@ let watcher = NotificationWatcher(globalNotification: .focusedUIElementChanged) 
 try watcher.start()
 ```
 
-Workspace snapshots are reconciled after the KVO callback returns. Membership in `runningApplications` supplies
-termination state without querying every application's `isTerminated` property; queued callbacks are discarded when
-the watcher stops, including across a restart.
+Complete workspace snapshots are reconciled in order after KVO delivery. PID and launch-readiness reads, readiness
+subscription, and its cleanup run on one serial background queue; a blocked metadata read leaves the main actor and
+stop responsive. Membership supplies termination state without querying `isTerminated`. Session and membership
+generations discard late results after stop, restart, or replacement, including removal and re-addition of the same
+application. A blocked native read can delay subsequent metadata work until it returns; it does not spawn extra workers.
 
 Applications that do not support the requested notification are skipped. Starting installs lifecycle tracking and
 returns without waiting for per-application Accessibility endpoints; observer creation, registration, and cleanup run

--- a/README.md
+++ b/README.md
@@ -529,6 +529,8 @@ subscription, and its cleanup run on one serial background queue; a blocked meta
 stop responsive. Membership supplies termination state without querying `isTerminated`. Session and membership
 generations discard late results after stop, restart, or replacement, including removal and re-addition of the same
 application. A blocked native read can delay subsequent metadata work until it returns; it does not spawn extra workers.
+Each readiness observation retains its exact application wrapper until invalidation completes, including queued cleanup
+after stop or wrapper replacement.
 
 Applications that do not support the requested notification are skipped. Starting installs lifecycle tracking and
 returns without waiting for per-application Accessibility endpoints; observer creation, registration, and cleanup run

--- a/Sources/AXorcist/Core/AXGlobalApplicationMonitor.swift
+++ b/Sources/AXorcist/Core/AXGlobalApplicationMonitor.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import os
 
 @MainActor
 protocol AXGlobalApplicationMonitoring: AnyObject, Sendable {
@@ -59,10 +60,10 @@ final class AXWorkspaceApplicationMonitor: AXGlobalApplicationMonitoring {
         self.sessionID = nil
         self.runningApplicationsObservation?.invalidate()
         self.runningApplicationsObservation = nil
-        for observation in self.readinessObservations.values {
-            observation.invalidate()
+        for request in self.metadataRequests.values {
+            request.cancel()
         }
-        self.readinessObservations = [:]
+        self.metadataRequests = [:]
         self.applicationsByIdentity = [:]
         self.onLaunch = nil
         self.onTermination = nil
@@ -72,91 +73,188 @@ final class AXWorkspaceApplicationMonitor: AXGlobalApplicationMonitoring {
         (@escaping @Sendable ([NSRunningApplication]) -> Void) -> NSKeyValueObservation
     private var sessionID: UUID?
     private var runningApplicationsObservation: NSKeyValueObservation?
-    private var readinessObservations: [NSRunningApplication: NSKeyValueObservation] = [:]
+    // Reuse one serial worker across sessions: a blocked read never creates replacement workers.
+    private let metadataQueue = DispatchQueue(label: "AXorcist.workspace-application-metadata")
+    private var metadataRequests: [NSRunningApplication: AXApplicationMetadataRequest] = [:]
     // Retain AppKit's semantic application keys: separate wrappers for one process instance
     // compare equal, while a replacement process remains a distinct application identity.
     private var applicationsByIdentity: [NSRunningApplication: pid_t] = [:]
     private var onLaunch: (@MainActor (pid_t) -> Void)?
     private var onTermination: (@MainActor (pid_t) -> Void)?
 
+    isolated deinit {
+        for request in self.metadataRequests.values {
+            request.cancel()
+        }
+    }
+
     private func reconcile(_ runningApplications: [NSRunningApplication], sessionID: UUID) {
-        // Workspace membership already identifies running apps. Querying isTerminated
-        // for each entry can synchronously block on LaunchServices.
-        let currentApplications = runningApplications
-            .reduce(into: [NSRunningApplication: pid_t]()) { applications, app in
-                let processIdentifier = app.processIdentifier
-                if processIdentifier > 0 {
-                    applications[app] = processIdentifier
-                }
-            }
-        let changes = Self.lifecycleChanges(
-            previous: self.applicationsByIdentity,
-            current: currentApplications)
-        let removedApplications = self.applicationsByIdentity.keys.filter { currentApplications[$0] == nil }
-        let addedApplications = currentApplications.keys.filter { self.applicationsByIdentity[$0] == nil }
+        // Process every complete snapshot in order, even when an earlier metadata read is blocked.
+        // Membership removal invalidates its request before a late PID/readiness result can arrive.
+        let currentApplications = Set(runningApplications)
+        let removedApplications = self.metadataRequests.keys.filter { !currentApplications.contains($0) }
+        var terminations: [pid_t] = []
         for application in removedApplications {
-            self.readinessObservations.removeValue(forKey: application)?.invalidate()
-        }
-        self.applicationsByIdentity = currentApplications
-        for processIdentifier in changes.terminations {
-            guard self.sessionID == sessionID else { return }
-            self.onTermination?(processIdentifier)
-        }
-        for application in addedApplications {
-            guard self.sessionID == sessionID else { return }
-            self.observeReadiness(of: application, sessionID: sessionID)
-        }
-        for processIdentifier in changes.launches {
-            guard self.sessionID == sessionID else { return }
-            self.onLaunch?(processIdentifier)
-        }
-    }
-
-    private func observeReadiness(of application: NSRunningApplication, sessionID: UUID) {
-        guard !application.isFinishedLaunching else { return }
-        let observation = application.observe(\.isFinishedLaunching, options: [.new]) { [weak self] app, change in
-            guard change.newValue == true else { return }
-            DispatchQueue.main.async { [weak self] in
-                self?.applicationBecameReady(app, sessionID: sessionID)
+            self.metadataRequests.removeValue(forKey: application)?.cancel()
+            if let pid = self.applicationsByIdentity.removeValue(forKey: application) {
+                terminations.append(pid)
             }
         }
-        self.readinessObservations[application] = observation
-        if application.isFinishedLaunching {
-            self.applicationBecameReady(application, sessionID: sessionID)
+        for pid in terminations.sorted() {
+            guard self.sessionID == sessionID else { return }
+            self.onTermination?(pid)
+        }
+        for application in runningApplications {
+            guard self.sessionID == sessionID else { return }
+            let request: AXApplicationMetadataRequest
+            if let existing = self.metadataRequests[application] {
+                request = existing
+            } else {
+                let requestID = UUID()
+                request = AXApplicationMetadataRequest(
+                    id: requestID,
+                    queue: self.metadataQueue)
+                { [weak self] event in
+                    guard let self, self.sessionID == sessionID,
+                          self.metadataRequests[application]?.id == requestID else { return }
+                    self.receive(event, from: application)
+                }
+                self.metadataRequests[application] = request
+            }
+            request.refresh(application)
         }
     }
 
-    private func applicationBecameReady(_ application: NSRunningApplication, sessionID: UUID) {
-        guard self.sessionID == sessionID,
-              let processIdentifier = self.applicationsByIdentity[application],
-              let observation = Self.claimReadiness(
-                  for: application,
-                  activeApplications: Set(self.applicationsByIdentity.keys),
-                  observations: &self.readinessObservations)
-        else { return }
+    private func receive(_ event: AXApplicationMetadataRequest.Event, from application: NSRunningApplication) {
+        switch event {
+        case let .pid(pid):
+            guard pid > 0 else {
+                if let previous = self.applicationsByIdentity.removeValue(forKey: application) {
+                    self.onTermination?(previous)
+                }
+                return
+            }
+            let previous = self.applicationsByIdentity.updateValue(pid, forKey: application)
+            if previous == nil {
+                self.onLaunch?(pid)
+            }
+        case .ready:
+            guard let pid = self.applicationsByIdentity[application] else { return }
+            self.onLaunch?(pid)
+        }
+    }
+}
+
+/// AppKit documents NSRunningApplication as thread-safe and the SDK marks it Sendable.
+/// Only cancellation/observation ownership uses the lock; native calls always run outside it.
+private final nonisolated class AXApplicationMetadataRequest: Sendable {
+    enum Event: Sendable {
+        case pid(pid_t)
+        case ready
+    }
+
+    private struct State {
+        var cancelled = false
+        var readinessStarted = false
+        var observation: (id: UUID, token: NSKeyValueObservation)?
+    }
+
+    let id: UUID
+    private let queue: DispatchQueue
+    private let deliver: @MainActor @Sendable (Event) -> Void
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    init(
+        id: UUID,
+        queue: DispatchQueue,
+        deliver: @escaping @MainActor @Sendable (Event) -> Void)
+    {
+        self.id = id
+        self.queue = queue
+        self.deliver = deliver
+    }
+
+    func cancel() {
+        let observation = self.state.withLock {
+            $0.cancelled = true
+            let observation = $0.observation
+            $0.observation = nil
+            return observation?.token
+        }
+        // Invalidation can contend with KVO delivery; stop must never join native work.
+        self.queue.async { observation?.invalidate() }
+    }
+
+    func refresh(_ application: NSRunningApplication) {
+        self.queue.async { [self] in
+            guard !self.isCancelled else { return }
+            let pid = application.processIdentifier
+            guard !self.isCancelled else { return }
+            self.send(.pid(pid))
+            guard pid > 0 else {
+                self.resetReadiness()
+                return
+            }
+            let shouldObserve = self.state.withLock {
+                guard !$0.cancelled, !$0.readinessStarted else { return false }
+                $0.readinessStarted = true
+                return true
+            }
+            if shouldObserve {
+                self.observeReadiness(of: application)
+            }
+        }
+    }
+
+    private var isCancelled: Bool {
+        self.state.withLock { $0.cancelled }
+    }
+
+    private func resetReadiness() {
+        let observation = self.state.withLock {
+            $0.readinessStarted = false
+            let observation = $0.observation
+            $0.observation = nil
+            return observation?.token
+        }
+        observation?.invalidate()
+    }
+
+    private func observeReadiness(of application: NSRunningApplication) {
+        guard !application.isFinishedLaunching, !self.isCancelled else { return }
+        let observationID = UUID()
+        // Do not request .new: KVO would fetch readiness synchronously on the notifying thread.
+        let observation = application.observe(\.isFinishedLaunching, options: []) { [weak self] application, _ in
+            guard let self else { return }
+            self.queue.async { self.checkReadiness(of: application, observationID: observationID) }
+        }
+        let installed = self.state.withLock {
+            guard !$0.cancelled else { return false }
+            $0.observation = (observationID, observation)
+            return true
+        }
+        guard installed else {
+            observation.invalidate()
+            return
+        }
+        self.checkReadiness(of: application, observationID: observationID)
+    }
+
+    private func checkReadiness(of application: NSRunningApplication, observationID: UUID) {
+        guard self.state.withLock({ !$0.cancelled && $0.observation?.id == observationID }),
+              application.isFinishedLaunching else { return }
+        let observation = self.state.withLock {
+            guard !$0.cancelled, $0.observation?.id == observationID else { return nil as NSKeyValueObservation? }
+            let observation = $0.observation
+            $0.observation = nil
+            return observation?.token
+        }
+        guard let observation else { return }
         observation.invalidate()
-        self.onLaunch?(processIdentifier)
+        self.send(.ready)
     }
 
-    static func claimReadiness<Identity: Hashable, Observation>(
-        for identity: Identity,
-        activeApplications: Set<Identity>,
-        observations: inout [Identity: Observation]) -> Observation?
-    {
-        guard activeApplications.contains(identity) else { return nil }
-        return observations.removeValue(forKey: identity)
-    }
-
-    static func lifecycleChanges<Identity: Hashable>(
-        previous: [Identity: pid_t],
-        current: [Identity: pid_t]) -> (terminations: [pid_t], launches: [pid_t])
-    {
-        let terminations = previous.compactMap { identity, processIdentifier in
-            current[identity] == nil ? processIdentifier : nil
-        }.sorted()
-        let launches = current.compactMap { identity, processIdentifier in
-            previous[identity] == nil ? processIdentifier : nil
-        }.sorted()
-        return (terminations, launches)
+    private func send(_ event: Event) {
+        DispatchQueue.main.async { [deliver] in deliver(event) }
     }
 }

--- a/Sources/AXorcist/Core/AXGlobalApplicationMonitor.swift
+++ b/Sources/AXorcist/Core/AXGlobalApplicationMonitor.swift
@@ -156,7 +156,21 @@ private final nonisolated class AXApplicationMetadataRequest: Sendable {
     private struct State {
         var cancelled = false
         var readinessStarted = false
-        var observation: (id: UUID, token: NSKeyValueObservation)?
+        var observation: ReadinessObservation?
+    }
+
+    private struct ReadinessObservation: Sendable {
+        let id: UUID
+        let application: NSRunningApplication
+        let token: NSKeyValueObservation
+
+        func invalidate() {
+            // Foundation's token does not keep its target alive. Retain the exact wrapper
+            // through unregistering, even if ARC ends the lease's lifetime at this call.
+            withExtendedLifetime(self.application) {
+                self.token.invalidate()
+            }
+        }
     }
 
     let id: UUID
@@ -179,7 +193,7 @@ private final nonisolated class AXApplicationMetadataRequest: Sendable {
             $0.cancelled = true
             let observation = $0.observation
             $0.observation = nil
-            return observation?.token
+            return observation
         }
         // Invalidation can contend with KVO delivery; stop must never join native work.
         self.queue.async { observation?.invalidate() }
@@ -215,7 +229,7 @@ private final nonisolated class AXApplicationMetadataRequest: Sendable {
             $0.readinessStarted = false
             let observation = $0.observation
             $0.observation = nil
-            return observation?.token
+            return observation
         }
         observation?.invalidate()
     }
@@ -224,13 +238,14 @@ private final nonisolated class AXApplicationMetadataRequest: Sendable {
         guard !application.isFinishedLaunching, !self.isCancelled else { return }
         let observationID = UUID()
         // Do not request .new: KVO would fetch readiness synchronously on the notifying thread.
-        let observation = application.observe(\.isFinishedLaunching, options: []) { [weak self] application, _ in
+        let token = application.observe(\.isFinishedLaunching, options: []) { [weak self] application, _ in
             guard let self else { return }
             self.queue.async { self.checkReadiness(of: application, observationID: observationID) }
         }
+        let observation = ReadinessObservation(id: observationID, application: application, token: token)
         let installed = self.state.withLock {
             guard !$0.cancelled else { return false }
-            $0.observation = (observationID, observation)
+            $0.observation = observation
             return true
         }
         guard installed else {
@@ -244,10 +259,10 @@ private final nonisolated class AXApplicationMetadataRequest: Sendable {
         guard self.state.withLock({ !$0.cancelled && $0.observation?.id == observationID }),
               application.isFinishedLaunching else { return }
         let observation = self.state.withLock {
-            guard !$0.cancelled, $0.observation?.id == observationID else { return nil as NSKeyValueObservation? }
+            guard !$0.cancelled, $0.observation?.id == observationID else { return nil as ReadinessObservation? }
             let observation = $0.observation
             $0.observation = nil
-            return observation?.token
+            return observation
         }
         guard let observation else { return }
         observation.invalidate()

--- a/Tests/AXorcistTests/ObserverLifecycleTests.swift
+++ b/Tests/AXorcistTests/ObserverLifecycleTests.swift
@@ -554,24 +554,6 @@ extension ObserverLifecycleTests {
     }
 
     @Test
-    func `application readiness can be claimed exactly once`() {
-        var observations = ["slow-app": 42]
-        let activeApplications: Set = ["slow-app"]
-
-        let firstClaim = AXWorkspaceApplicationMonitor.claimReadiness(
-            for: "slow-app",
-            activeApplications: activeApplications,
-            observations: &observations)
-        let duplicateClaim = AXWorkspaceApplicationMonitor.claimReadiness(
-            for: "slow-app",
-            activeApplications: activeApplications,
-            observations: &observations)
-
-        #expect(firstClaim == 42)
-        #expect(duplicateClaim == nil)
-    }
-
-    @Test
     func `global watcher bounds persistent launched application retries`() async throws {
         let registry = RecordingObservationRegistry(failingProcessIdentifiers: [42])
         let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [41])
@@ -737,42 +719,6 @@ extension ObserverLifecycleTests {
         #expect(registry.activeProcessIdentifiers == [42])
         watcher.stop()
         #expect(registry.activeProcessIdentifiers.isEmpty)
-    }
-
-    @Test
-    func `workspace application diff preserves replacement events when a PID is reused`() {
-        let changes = AXWorkspaceApplicationMonitor.lifecycleChanges(
-            previous: ["stable": pid_t(7), "old-generation": pid_t(42)],
-            current: ["stable": pid_t(7), "agent": pid_t(9), "new-generation": pid_t(42)])
-
-        #expect(changes.terminations == [42])
-        #expect(changes.launches == [9, 42])
-    }
-
-    @Test
-    func `workspace application diff ignores wrapper churn for one semantic application`() {
-        let oldWrapper = RunningApplicationIdentityDouble(processInstance: "stable", wrapperAddress: 100)
-        let newWrapper = RunningApplicationIdentityDouble(processInstance: "stable", wrapperAddress: 200)
-
-        let changes = AXWorkspaceApplicationMonitor.lifecycleChanges(
-            previous: [oldWrapper: pid_t(42)],
-            current: [newWrapper: pid_t(42)])
-
-        #expect(changes.terminations.isEmpty)
-        #expect(changes.launches.isEmpty)
-    }
-
-    @Test
-    func `workspace application diff detects semantic replacement despite address reuse`() {
-        let oldApplication = RunningApplicationIdentityDouble(processInstance: "old", wrapperAddress: 100)
-        let replacement = RunningApplicationIdentityDouble(processInstance: "new", wrapperAddress: 100)
-
-        let changes = AXWorkspaceApplicationMonitor.lifecycleChanges(
-            previous: [oldApplication: pid_t(42)],
-            current: [replacement: pid_t(42)])
-
-        #expect(changes.terminations == [42])
-        #expect(changes.launches == [42])
     }
 
     @Test
@@ -980,19 +926,6 @@ private final class RecordingGlobalApplicationMonitor: AXGlobalApplicationMonito
 
     func ready(processIdentifier: pid_t) {
         self.onLaunch?(processIdentifier)
-    }
-}
-
-private struct RunningApplicationIdentityDouble: Hashable {
-    let processInstance: String
-    let wrapperAddress: Int
-
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.processInstance == rhs.processInstance
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(self.processInstance)
     }
 }
 

--- a/Tests/AXorcistTests/WorkspaceApplicationMonitorTests.swift
+++ b/Tests/AXorcistTests/WorkspaceApplicationMonitorTests.swift
@@ -387,6 +387,108 @@ struct WorkspaceApplicationMonitorTests {
 }
 
 @MainActor
+extension WorkspaceApplicationMonitorTests {
+    @Test(arguments: ObservationEnd.allCases)
+    private func `readiness lease retains the exact wrapper through queued invalidation`(_ end: ObservationEnd) async {
+        let probe = ApplicationMetadataProbe()
+        let lifetime = ApplicationLifetimeProbe()
+        let workspace = MonitorWorkspace(applications: [MonitorApplication(instance: "same", pid: 0, probe: probe)])
+        var monitor: AXWorkspaceApplicationMonitor? = AXWorkspaceApplicationMonitor(
+            workspace: workspace, runningApplications: \.applications)
+        monitor?.start(onLaunch: { _ in }, onTermination: { _ in })
+        await workspace.flushMetadata()
+
+        // The request's original semantic key is not the wrapper on which KVO is installed.
+        let observed = workspace.replaceWithLifetimeApplication(probe: probe, lifetime: lifetime)
+        await workspace.flushMetadata()
+        #expect(lifetime.registrations == 1)
+
+        let gate = MetadataGate(read: .pid)
+        workspace.applications.append(MonitorApplication(instance: "blocker", pid: 43, probe: probe, gate: gate))
+        await gate.waitUntilEntered()
+        workspace.applications = [MonitorApplication(instance: "same", pid: 42, probe: probe)]
+        await drainMainQueue()
+        #expect(observed.value != nil, "Semantic wrapper churn must retain the exact KVO target")
+
+        switch end {
+        case .removal:
+            workspace.applications = []
+            await drainMainQueue()
+        case .stop:
+            monitor?.stop()
+            workspace.applications = []
+        case .destruction:
+            monitor = nil
+            workspace.applications = []
+        }
+        #expect(gate.isBlocked)
+        #expect(
+            observed.value != nil,
+            "Queued invalidation must own the observed wrapper until unregistering completes")
+        #expect(lifetime.removals == 0)
+        gate.release()
+        await lifetime.waitForDeallocation()
+        #expect(observed.value == nil)
+        #expect(lifetime.removals == 1)
+        #expect(!lifetime.deallocatedWhileObserved)
+        monitor?.stop()
+    }
+
+    @Test(arguments: ObservationInvalidation.allCases)
+    private func `readiness lease survives invalidation completion and installation cancellation`(
+        _ invalidation: ObservationInvalidation) async
+    {
+        let probe = ApplicationMetadataProbe()
+        let installation = ObservationGate()
+        let removal = ObservationGate()
+        let lifetime = ApplicationLifetimeProbe(
+            afterRegistration: {
+                if invalidation == .cancelledInstallation {
+                    installation.hold()
+                }
+            },
+            beforeRemovalReturns: { removal.hold() })
+        let workspace = MonitorWorkspace(applications: [MonitorApplication(instance: "same", pid: 0, probe: probe)])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        var launches: [pid_t] = []
+        monitor.start(onLaunch: { launches.append($0) }, onTermination: { _ in })
+        await workspace.flushMetadata()
+        let observed = workspace.replaceWithLifetimeApplication(probe: probe, lifetime: lifetime)
+
+        if invalidation == .cancelledInstallation {
+            await installation.waitUntilEntered()
+            monitor.stop()
+            workspace.applications = []
+            #expect(observed.value != nil)
+            installation.release()
+        } else {
+            await workspace.flushMetadata()
+            workspace.applications = [MonitorApplication(
+                instance: "same", pid: invalidation == .reset ? 0 : 42, probe: probe)]
+            if invalidation == .readiness {
+                observed.value?.finishLaunching()
+            }
+        }
+        await removal.waitUntilEntered()
+        monitor.stop()
+        workspace.applications = []
+        let launchesAtStop = launches
+        #expect(observed.value != nil, "The exact target must survive until invalidate returns")
+        #expect(lifetime.removals == 0)
+        #expect(monitor.runningProcessIdentifiers.isEmpty)
+        removal.release()
+        await lifetime.waitForDeallocation()
+        #expect(observed.value == nil)
+        #expect(lifetime.removals == 1)
+        #expect(!lifetime.deallocatedWhileObserved)
+        monitor.start(onLaunch: { launches.append($0) }, onTermination: { _ in })
+        await workspace.flushMetadata()
+        #expect(launches == launchesAtStop)
+        monitor.stop()
+    }
+}
+
+@MainActor
 private func drainMainQueue() async {
     await withCheckedContinuation { continuation in
         DispatchQueue.main.async { continuation.resume() }
@@ -431,6 +533,88 @@ private nonisolated enum MetadataRead: Sendable {
     case pid, readinessCheck, readinessRecheck, readinessNotification
 
     static let initialReads: [Self] = [.pid, .readinessCheck, .readinessRecheck]
+}
+
+private nonisolated enum ObservationEnd: CaseIterable, Sendable {
+    case removal, stop, destruction
+}
+
+private nonisolated enum ObservationInvalidation: CaseIterable, Sendable {
+    case reset, readiness, cancelledInstallation
+}
+
+private final nonisolated class ObservationGate: Sendable {
+    private let entry = AsyncStream<Void>.makeStream()
+    private let semaphore = DispatchSemaphore(value: 0)
+
+    func hold() {
+        #expect(!Thread.isMainThread)
+        self.entry.continuation.yield(())
+        if !Thread.isMainThread {
+            self.semaphore.wait()
+        }
+    }
+
+    func waitUntilEntered() async {
+        var iterator = self.entry.stream.makeAsyncIterator()
+        _ = await iterator.next()
+    }
+
+    func release() {
+        self.semaphore.signal()
+    }
+}
+
+private final nonisolated class ApplicationLifetimeProbe: Sendable {
+    private struct State {
+        var registrations = 0
+        var removals = 0
+        var deallocatedWhileObserved = false
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private let deallocation = AsyncStream<Void>.makeStream()
+    private let afterRegistration: (@Sendable () -> Void)?
+    private let beforeRemovalReturns: (@Sendable () -> Void)?
+
+    init(afterRegistration: (@Sendable () -> Void)? = nil, beforeRemovalReturns: (@Sendable () -> Void)? = nil) {
+        self.afterRegistration = afterRegistration
+        self.beforeRemovalReturns = beforeRemovalReturns
+    }
+
+    var registrations: Int {
+        self.state.withLock { $0.registrations }
+    }
+
+    var removals: Int {
+        self.state.withLock { $0.removals }
+    }
+
+    var deallocatedWhileObserved: Bool {
+        self.state.withLock { $0.deallocatedWhileObserved }
+    }
+
+    func registered() {
+        #expect(!Thread.isMainThread)
+        self.state.withLock { $0.registrations += 1 }
+        self.afterRegistration?()
+    }
+
+    func removed() {
+        #expect(!Thread.isMainThread)
+        self.beforeRemovalReturns?()
+        self.state.withLock { $0.removals += 1 }
+    }
+
+    func deallocated() {
+        self.state.withLock { $0.deallocatedWhileObserved = $0.registrations > $0.removals }
+        self.deallocation.continuation.yield(())
+    }
+
+    func waitForDeallocation() async {
+        var iterator = self.deallocation.stream.makeAsyncIterator()
+        _ = await iterator.next()
+    }
 }
 
 private final nonisolated class MetadataGate: Sendable {
@@ -525,6 +709,22 @@ private final class MonitorWorkspace: NSObject {
         super.init()
     }
 
+    func replaceWithLifetimeApplication(
+        probe: ApplicationMetadataProbe,
+        lifetime: ApplicationLifetimeProbe) -> WeakMonitorApplication
+    {
+        autoreleasepool {
+            let application = MonitorApplication(
+                instance: "same",
+                pid: 42,
+                ready: false,
+                probe: probe,
+                lifetime: lifetime)
+            self.applications = [application]
+            return WeakMonitorApplication(application)
+        }
+    }
+
     /// A synthetic invalid-PID member is an observable fence behind earlier metadata work.
     /// No production queue/test hook or timing assumption is needed.
     func flushMetadata() async {
@@ -541,12 +741,25 @@ private final class MonitorWorkspace: NSObject {
     }
 }
 
+@MainActor
+private final class WeakMonitorApplication {
+    weak var value: MonitorApplication?
+
+    init(_ application: MonitorApplication) {
+        self.value = application
+    }
+}
+
 private final nonisolated class MonitorApplication: NSRunningApplication, @unchecked Sendable {
+    // Foundation may try to unregister during super.deinit, after Swift stored properties are gone.
+    // Keep the baseline regression an assertion failure instead of calling AppKit on that dead state.
+    private static let deallocating = OSAllocatedUnfairLock(initialState: Set<ObjectIdentifier>())
     private let instance: String
     private let pid: pid_t
     private let probe: ApplicationMetadataProbe
     private let ready: OSAllocatedUnfairLock<Bool>
     private let gate: MetadataGate?
+    private let lifetime: ApplicationLifetimeProbe?
     private let onPIDRead: (@Sendable () -> Void)?
 
     @MainActor
@@ -556,6 +769,7 @@ private final nonisolated class MonitorApplication: NSRunningApplication, @unche
         ready: Bool = true,
         probe: ApplicationMetadataProbe,
         gate: MetadataGate? = nil,
+        lifetime: ApplicationLifetimeProbe? = nil,
         onPIDRead: (@Sendable () -> Void)? = nil)
     {
         self.instance = instance
@@ -563,8 +777,33 @@ private final nonisolated class MonitorApplication: NSRunningApplication, @unche
         self.ready = OSAllocatedUnfairLock(initialState: ready)
         self.probe = probe
         self.gate = gate
+        self.lifetime = lifetime
         self.onPIDRead = onPIDRead
         super.init()
+        _ = Self.deallocating.withLock { $0.remove(ObjectIdentifier(self)) }
+    }
+
+    deinit {
+        if let lifetime = self.lifetime {
+            _ = Self.deallocating.withLock { $0.insert(ObjectIdentifier(self)) }
+            lifetime.deallocated()
+        }
+    }
+
+    override func addObserver(
+        _ observer: NSObject,
+        forKeyPath keyPath: String,
+        options: NSKeyValueObservingOptions = [],
+        context: UnsafeMutableRawPointer?)
+    {
+        super.addObserver(observer, forKeyPath: keyPath, options: options, context: context)
+        self.lifetime?.registered()
+    }
+
+    override func removeObserver(_ observer: NSObject, forKeyPath keyPath: String, context: UnsafeMutableRawPointer?) {
+        guard !Self.deallocating.withLock({ $0.contains(ObjectIdentifier(self)) }) else { return }
+        super.removeObserver(observer, forKeyPath: keyPath, context: context)
+        self.lifetime?.removed()
     }
 
     override var processIdentifier: pid_t {

--- a/Tests/AXorcistTests/WorkspaceApplicationMonitorTests.swift
+++ b/Tests/AXorcistTests/WorkspaceApplicationMonitorTests.swift
@@ -1,11 +1,156 @@
 import AppKit
 import Foundation
+import os
 import Testing
 @testable import AXorcist
 
-@Suite("Workspace application monitor")
+@Suite("Workspace application monitor", .timeLimit(.minutes(1)))
 @MainActor
 struct WorkspaceApplicationMonitorTests {
+    @Test(arguments: MetadataRead.initialReads)
+    private func `blocked metadata leaves MainActor and stop responsive`(_ read: MetadataRead) async {
+        let gate = MetadataGate(read: read)
+        let probe = ApplicationMetadataProbe()
+        let application = MonitorApplication(instance: "blocked", pid: 42, ready: false, probe: probe, gate: gate)
+        let workspace = MonitorWorkspace(applications: [application])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        var launches: [pid_t] = []
+        monitor.start(onLaunch: { launches.append($0) }, onTermination: { _ in })
+        await gate.waitUntilEntered()
+
+        // A main-thread getter reports the regression and returns instead of deadlocking the test runner.
+        #expect(gate.isBlocked, "The metadata read must still be held while MainActor makes progress")
+        monitor.stop()
+        #expect(monitor.runningProcessIdentifiers.isEmpty)
+        let launchesAtStop = launches
+        gate.release()
+        workspace.applications = []
+        monitor.start(onLaunch: { launches.append($0) }, onTermination: { _ in })
+        await workspace.flushMetadata()
+        #expect(launches == launchesAtStop)
+        monitor.stop()
+    }
+
+    @Test(arguments: MetadataRead.initialReads)
+    private func `blocked metadata cannot revive the previous session`(_ read: MetadataRead) async {
+        let gate = MetadataGate(read: read)
+        let probe = ApplicationMetadataProbe()
+        let previous = MonitorApplication(instance: "previous", pid: 41, ready: false, probe: probe, gate: gate)
+        let replacement = MonitorApplication(instance: "replacement", pid: 42, probe: probe)
+        let workspace = MonitorWorkspace(applications: [previous])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        var oldLaunches: [pid_t] = []
+        var newLaunches: [pid_t] = []
+        monitor.start(onLaunch: { oldLaunches.append($0) }, onTermination: { _ in })
+        await gate.waitUntilEntered()
+        monitor.stop()
+        let launchesAtStop = oldLaunches
+        workspace.applications = [replacement]
+        monitor.start(onLaunch: { newLaunches.append($0) }, onTermination: { _ in })
+        await drainMainQueue()
+
+        #expect(gate.isBlocked)
+        #expect(monitor.runningProcessIdentifiers.isEmpty)
+        gate.release()
+        await workspace.flushMetadata()
+        #expect(oldLaunches == launchesAtStop)
+        #expect(newLaunches == [42])
+        #expect(monitor.runningProcessIdentifiers == [42])
+        monitor.stop()
+    }
+
+    @Test(arguments: MetadataRead.initialReads, [false, true])
+    private func `blocked metadata cannot escape membership removal`(
+        _ read: MetadataRead,
+        sameIdentity: Bool) async
+    {
+        let gate = MetadataGate(read: read)
+        let probe = ApplicationMetadataProbe()
+        let previous = MonitorApplication(instance: "previous", pid: 42, ready: false, probe: probe, gate: gate)
+        let replacement = MonitorApplication(
+            instance: sameIdentity ? "previous" : "replacement", pid: 42, ready: false, probe: probe)
+        let workspace = MonitorWorkspace(applications: [previous])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        var events: [String] = []
+        monitor.start(onLaunch: { events.append("launch:\($0)") }, onTermination: { events.append("terminate:\($0)") })
+        await gate.waitUntilEntered()
+        await drainMainQueue()
+        let initialEvents = events
+        if sameIdentity {
+            workspace.applications = []
+        }
+        workspace.applications = [replacement]
+        await drainMainQueue()
+
+        #expect(gate.isBlocked)
+        #expect(monitor.runningProcessIdentifiers.isEmpty)
+        let removedEvents = initialEvents.isEmpty ? [] : ["launch:42", "terminate:42"]
+        #expect(events == removedEvents)
+        gate.release()
+        await workspace.flushMetadata()
+        #expect(events == removedEvents + ["launch:42"])
+        previous.finishLaunching()
+        previous.finishLaunching()
+        await workspace.flushMetadata()
+        #expect(events == removedEvents + ["launch:42"])
+        replacement.finishLaunching()
+        replacement.finishLaunching()
+        await workspace.flushMetadata()
+        #expect(events == removedEvents + ["launch:42", "launch:42"])
+        #expect(monitor.runningProcessIdentifiers == [42])
+        monitor.stop()
+    }
+
+    @Test(arguments: [MetadataRead.readinessCheck, .readinessRecheck])
+    private func `readiness check subscribe recheck closes both transition races`(_ read: MetadataRead) async {
+        let gate = MetadataGate(read: read)
+        let probe = ApplicationMetadataProbe()
+        let application = MonitorApplication(instance: "slow", pid: 42, ready: false, probe: probe, gate: gate)
+        let workspace = MonitorWorkspace(applications: [application])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        var launches: [pid_t] = []
+        monitor.start(onLaunch: { launches.append($0) }, onTermination: { _ in })
+        await gate.waitUntilEntered()
+        probe.insideCallback = true
+        application.finishLaunching()
+        application.finishLaunching()
+        probe.insideCallback = false
+        #expect(gate.isBlocked)
+        gate.release()
+        await workspace.flushMetadata()
+
+        #expect(launches == [42, 42])
+        #expect(probe.reentrantMetadataReads == 0)
+        monitor.stop()
+    }
+
+    @Test
+    func `readiness notification defers its blocked getter and stop discards the result`() async {
+        let gate = MetadataGate(read: .readinessNotification)
+        let probe = ApplicationMetadataProbe()
+        let application = MonitorApplication(instance: "slow", pid: 42, ready: false, probe: probe, gate: gate)
+        let workspace = MonitorWorkspace(applications: [application])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        var launches: [pid_t] = []
+        monitor.start(onLaunch: { launches.append($0) }, onTermination: { _ in })
+        await workspace.flushMetadata()
+        probe.insideCallback = true
+        application.finishLaunching()
+        probe.insideCallback = false
+        await gate.waitUntilEntered()
+
+        #expect(gate.isBlocked)
+        #expect(probe.reentrantMetadataReads == 0)
+        monitor.stop()
+        gate.release()
+        workspace.applications = []
+        monitor.start(onLaunch: { launches.append($0) }, onTermination: { _ in })
+        await workspace.flushMetadata()
+        #expect(launches == [42])
+        #expect(monitor.runningProcessIdentifiers.isEmpty)
+        monitor.stop()
+    }
+
     @Test(.timeLimit(.minutes(1)))
     func `global watcher registers the deferred initial snapshot once before backoff`() async throws {
         let probe = ApplicationMetadataProbe()
@@ -26,7 +171,7 @@ struct WorkspaceApplicationMonitorTests {
         #expect(watcher.isActive)
         var iterator = attempts.makeAsyncIterator()
         #expect(await iterator.next() == 42)
-        await drainMainQueue()
+        await workspace.flushMetadata()
 
         #expect(registry.processIdentifiers == [42])
         #expect(monitor.runningProcessIdentifiers == [42])
@@ -43,13 +188,13 @@ struct WorkspaceApplicationMonitorTests {
         probe.insideCallback = true
         monitor.start(onLaunch: { events.append("launch:\($0)") }, onTermination: { events.append("terminate:\($0)") })
         probe.insideCallback = false
-        await drainMainQueue()
+        await workspace.flushMetadata()
         #expect(monitor.runningProcessIdentifiers == [42])
 
         probe.insideCallback = true
         workspace.applications = []
         probe.insideCallback = false
-        await drainMainQueue()
+        await workspace.flushMetadata()
 
         #expect(events == ["launch:42", "terminate:42"])
         #expect(monitor.runningProcessIdentifiers.isEmpty)
@@ -68,10 +213,13 @@ struct WorkspaceApplicationMonitorTests {
         let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
         var events: [String] = []
         monitor.start(onLaunch: { events.append("launch:\($0)") }, onTermination: { events.append("terminate:\($0)") })
+        await workspace.flushMetadata()
         workspace.applications = [equalWrapper]
+        await workspace.flushMetadata()
+        #expect(events == ["launch:42"])
         workspace.applications = []
         workspace.applications = [replacement]
-        await drainMainQueue()
+        await workspace.flushMetadata()
 
         #expect(events == ["launch:42", "terminate:42", "launch:42"])
         #expect(monitor.runningProcessIdentifiers == [42])
@@ -91,15 +239,32 @@ struct WorkspaceApplicationMonitorTests {
         applications.add(added)
         applications.add(MonitorApplication(instance: "no-pid", pid: -1, probe: probe))
         applications.add(MonitorApplication(instance: "zero", pid: 0, probe: probe))
-        await drainMainQueue()
+        await workspace.flushMetadata()
 
         #expect(events == ["launch:41", "launch:42"])
         #expect(monitor.runningProcessIdentifiers.sorted() == [41, 42])
         applications.removeObject(at: 0)
-        await drainMainQueue()
+        await workspace.flushMetadata()
 
         #expect(events == ["launch:41", "launch:42", "terminate:41"])
         #expect(monitor.runningProcessIdentifiers == [42])
+        monitor.stop()
+    }
+
+    @Test
+    func `ordered snapshots preserve positive PID transitions for equal wrappers`() async {
+        let probe = ApplicationMetadataProbe()
+        let workspace = MonitorWorkspace(applications: [MonitorApplication(instance: "same", pid: -1, probe: probe)])
+        let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
+        var events: [String] = []
+        monitor.start(onLaunch: { events.append("launch:\($0)") }, onTermination: { events.append("terminate:\($0)") })
+        workspace.applications = [MonitorApplication(instance: "same", pid: 42, probe: probe)]
+        workspace.applications = [MonitorApplication(instance: "same", pid: 0, probe: probe)]
+        workspace.applications = [MonitorApplication(instance: "same", pid: 43, probe: probe)]
+        await workspace.flushMetadata()
+
+        #expect(events == ["launch:42", "terminate:42", "launch:43"])
+        #expect(monitor.runningProcessIdentifiers == [43])
         monitor.stop()
     }
 
@@ -118,7 +283,7 @@ struct WorkspaceApplicationMonitorTests {
         monitor.start(
             onLaunch: { currentEvents.append("launch:\($0)") },
             onTermination: { currentEvents.append("terminate:\($0)") })
-        await drainMainQueue()
+        await workspace.flushMetadata()
 
         #expect(stoppedEvents.isEmpty)
         #expect(currentEvents == ["launch:42"])
@@ -140,17 +305,18 @@ struct WorkspaceApplicationMonitorTests {
                 reentrantLaunches += 1
             }
         }, onTermination: { _ in })
-        await drainMainQueue()
+        await workspace.flushMetadata()
         #expect(launches == [42])
 
         probe.insideCallback = true
         application.finishLaunching()
         application.finishLaunching()
         probe.insideCallback = false
-        await drainMainQueue()
+        await workspace.flushMetadata()
 
         #expect(launches == [42, 42])
         #expect(reentrantLaunches == 0)
+        #expect(probe.reentrantMetadataReads == 0)
         monitor.stop()
     }
 
@@ -163,11 +329,11 @@ struct WorkspaceApplicationMonitorTests {
         var oldLaunches: [pid_t] = []
         var newLaunches: [pid_t] = []
         monitor.start(onLaunch: { oldLaunches.append($0) }, onTermination: { _ in })
-        await drainMainQueue()
+        await workspace.flushMetadata()
         application.finishLaunching()
         monitor.stop()
         monitor.start(onLaunch: { newLaunches.append($0) }, onTermination: { _ in })
-        await drainMainQueue()
+        await workspace.flushMetadata()
 
         #expect(oldLaunches == [42])
         #expect(newLaunches == [42])
@@ -182,10 +348,10 @@ struct WorkspaceApplicationMonitorTests {
         let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
         var events: [String] = []
         monitor.start(onLaunch: { events.append("launch:\($0)") }, onTermination: { events.append("terminate:\($0)") })
-        await drainMainQueue()
+        await workspace.flushMetadata()
         workspace.applications = []
         application.finishLaunching()
-        await drainMainQueue()
+        await workspace.flushMetadata()
 
         #expect(events == ["launch:42", "terminate:42"])
         #expect(monitor.runningProcessIdentifiers.isEmpty)
@@ -201,14 +367,22 @@ struct WorkspaceApplicationMonitorTests {
         ])
         let monitor = AXWorkspaceApplicationMonitor(workspace: workspace, runningApplications: \.applications)
         var launches: [pid_t] = []
+        let stopped = AsyncStream<Void>.makeStream()
         monitor.start(onLaunch: {
             launches.append($0)
             monitor.stop()
+            stopped.continuation.yield(())
         }, onTermination: { _ in })
-        await drainMainQueue()
+        var iterator = stopped.stream.makeAsyncIterator()
+        _ = await iterator.next()
+        #expect(monitor.runningProcessIdentifiers.isEmpty)
+        workspace.applications = []
+        monitor.start(onLaunch: { launches.append($0) }, onTermination: { _ in })
+        await workspace.flushMetadata()
 
         #expect(launches == [41])
         #expect(monitor.runningProcessIdentifiers.isEmpty)
+        monitor.stop()
     }
 }
 
@@ -219,16 +393,97 @@ private func drainMainQueue() async {
     }
 }
 
-@MainActor
-private final class ApplicationMetadataProbe {
-    var insideCallback = false
-    var terminationReads = 0
-    var reentrantMetadataReads = 0
+private final nonisolated class ApplicationMetadataProbe: Sendable {
+    private struct State {
+        var insideCallback = false
+        var terminationReads = 0
+        var reentrantMetadataReads = 0
+    }
 
-    func recordRead() {
-        if self.insideCallback {
-            self.reentrantMetadataReads += 1
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    var insideCallback: Bool {
+        get { self.state.withLock { $0.insideCallback } }
+        set { self.state.withLock { $0.insideCallback = newValue } }
+    }
+
+    var terminationReads: Int {
+        self.state.withLock { $0.terminationReads }
+    }
+
+    var reentrantMetadataReads: Int {
+        self.state.withLock { $0.reentrantMetadataReads }
+    }
+
+    func recordRead(termination: Bool = false) {
+        self.state.withLock {
+            // The synthetic KVO setters run on MainActor; concurrent background reads are allowed.
+            if $0.insideCallback, Thread.isMainThread {
+                $0.reentrantMetadataReads += 1
+            }
+            if termination {
+                $0.terminationReads += 1
+            }
         }
+    }
+}
+
+private nonisolated enum MetadataRead: Sendable {
+    case pid, readinessCheck, readinessRecheck, readinessNotification
+
+    static let initialReads: [Self] = [.pid, .readinessCheck, .readinessRecheck]
+}
+
+private final nonisolated class MetadataGate: Sendable {
+    private struct State {
+        var readinessReads = 0
+        var entered = false
+        var blocked = false
+    }
+
+    private let read: MetadataRead
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private let semaphore = DispatchSemaphore(value: 0)
+    private let entry = AsyncStream<Void>.makeStream()
+
+    init(read: MetadataRead) {
+        self.read = read
+    }
+
+    var isBlocked: Bool {
+        self.state.withLock { $0.blocked }
+    }
+
+    func visit(pid: Bool) {
+        let shouldBlock = self.state.withLock { state in
+            if !pid {
+                state.readinessReads += 1
+            }
+            let matches = switch self.read {
+            case .pid: pid
+            case .readinessCheck: !pid && state.readinessReads == 1
+            case .readinessRecheck: !pid && state.readinessReads == 2
+            case .readinessNotification: !pid && state.readinessReads == 3
+            }
+            guard matches, !state.entered else { return false }
+            state.entered = true
+            state.blocked = !Thread.isMainThread
+            return true
+        }
+        guard shouldBlock else { return }
+        #expect(!Thread.isMainThread, "Blocking application metadata was read on the main thread")
+        self.entry.continuation.yield(())
+        guard !Thread.isMainThread else { return }
+        self.semaphore.wait()
+        self.state.withLock { $0.blocked = false }
+    }
+
+    func waitUntilEntered() async {
+        var iterator = self.entry.stream.makeAsyncIterator()
+        _ = await iterator.next()
+    }
+
+    func release() {
+        self.semaphore.signal()
     }
 }
 
@@ -269,50 +524,73 @@ private final class MonitorWorkspace: NSObject {
         self.storedApplications = applications
         super.init()
     }
+
+    /// A synthetic invalid-PID member is an observable fence behind earlier metadata work.
+    /// No production queue/test hook or timing assumption is needed.
+    func flushMetadata() async {
+        await drainMainQueue()
+        let read = AsyncStream<Void>.makeStream()
+        let fence = MonitorApplication(instance: UUID().uuidString, pid: -1, probe: ApplicationMetadataProbe()) {
+            DispatchQueue.main.async { read.continuation.yield(()) }
+        }
+        self.applications.append(fence)
+        var iterator = read.stream.makeAsyncIterator()
+        _ = await iterator.next()
+        self.applications.removeAll { $0 === fence }
+        await drainMainQueue()
+    }
 }
 
 private final nonisolated class MonitorApplication: NSRunningApplication, @unchecked Sendable {
     private let instance: String
     private let pid: pid_t
     private let probe: ApplicationMetadataProbe
-    @MainActor private var ready: Bool
+    private let ready: OSAllocatedUnfairLock<Bool>
+    private let gate: MetadataGate?
+    private let onPIDRead: (@Sendable () -> Void)?
 
     @MainActor
-    init(instance: String, pid: pid_t, ready: Bool = true, probe: ApplicationMetadataProbe) {
+    init(
+        instance: String,
+        pid: pid_t,
+        ready: Bool = true,
+        probe: ApplicationMetadataProbe,
+        gate: MetadataGate? = nil,
+        onPIDRead: (@Sendable () -> Void)? = nil)
+    {
         self.instance = instance
         self.pid = pid
-        self.ready = ready
+        self.ready = OSAllocatedUnfairLock(initialState: ready)
         self.probe = probe
+        self.gate = gate
+        self.onPIDRead = onPIDRead
         super.init()
     }
 
     override var processIdentifier: pid_t {
-        MainActor.assumeIsolated {
-            self.probe.recordRead()
-            return self.pid
-        }
+        self.probe.recordRead()
+        self.gate?.visit(pid: true)
+        self.onPIDRead?()
+        return self.pid
     }
 
     override var isTerminated: Bool {
-        MainActor.assumeIsolated {
-            self.probe.recordRead()
-            self.probe.terminationReads += 1
-            return false
-        }
+        self.probe.recordRead(termination: true)
+        return false
     }
 
     override var isFinishedLaunching: Bool {
-        MainActor.assumeIsolated {
-            self.probe.recordRead()
-            return self.ready
-        }
+        self.probe.recordRead()
+        let ready = self.ready.withLock { $0 }
+        self.gate?.visit(pid: false)
+        return ready
     }
 
     @MainActor
     func finishLaunching() {
         let key = #keyPath(NSRunningApplication.isFinishedLaunching)
         self.willChangeValue(forKey: key)
-        self.ready = true
+        self.ready.withLock { $0 = true }
         self.didChangeValue(forKey: key)
     }
 


### PR DESCRIPTION
## Summary

Keep global workspace-monitor PID and launch-readiness work off the main actor. A signed macOS 27 integration run showed that `NSRunningApplication.processIdentifier` can itself wait synchronously on LaunchServices: deferring reconciliation out of KVO was not sufficient to keep the Bridge handshake responsive.

One serial background queue owns PID/readiness reads and readiness observation setup/cleanup. MainActor retains ordered complete membership snapshots, semantic application identity, cached PIDs and callbacks. Session, membership-request and observation generations discard late results; stop never joins a blocked metadata read. Readiness KVO no longer requests `.new`, avoiding an implicit getter on the notifying thread. A blocked native read can still delay later metadata work on the same queue; this does not claim a universal lifecycle-latency guarantee.

## Validation

- The final blocking regression fails against the previous production implementation for PID, initial readiness and readiness recheck, with six expected assertions across three cases.
- Fixed focused suite: 26 tests / 36 expanded cases passed. An independent rerun also passed all 26 tests.
- Coverage includes blocked reads, main-actor/stop responsiveness, stale session and membership results, semantic wrapper churn/replacement, indexed snapshots, readiness subscription races and callback-initiated stop.
- Changed Swift files pass SwiftFormat checking and strict SwiftLint. `git diff --check` passes.
- Isolated Codex autoreview: scoped-clean at the configured P0 threshold.
- Local proof uses Xcode 27. The native SwiftPM build-system flag and existing deprecated compatibility tests retain their reported warnings; this is not warning-free publication proof.

Four superseded pure-helper tests were removed with their production helpers; the actual monitor tests now cover those contracts. No polling, deadline increase, permission change, new dependency or public API was introduced.

**Before merge:** require green hosted compatibility CI and fresh signed native lifecycle/cold-handshake integration proof. The original failed integration run remains a failure; no uncertain input was replayed.
