### PR TITLE
chore(deps): refresh swift-log and SwiftLint

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "35f754252cf3111a509f6a9ee7ca1a07d40bbe953ef8bd9ac7150f2faf87174b",
+  "originHash" : "02fa0740b6372cc960cfbd1d6cd1b96bfea37aa09a3f7c647a6a7f0335d29753",
   "pins" : [
     {
       "identity" : "commander",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
-        "version" : "1.14.0"
+        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
+        "version" : "1.15.0"
       }
     }
   ],

--- a/scripts/install-validation-tools.sh
+++ b/scripts/install-validation-tools.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 swiftformat_version="0.62.1"
 swiftformat_sha256="7cb1cb1fae04932047c7015441c543848e8e60e1572d808d080e0a1f1661114a"
-swiftlint_version="0.65.0"
-swiftlint_sha256="d6cb0aa7a2f5f1ef306fc9e37bcb54dc9a26facc8f7784ac0c3dd3eccf5c6ba6"
+swiftlint_version="0.65.1"
+swiftlint_sha256="c1e429b0599cf1b516f369a2d9ec04eaf0e436f3c12b637df8851fa52ff694d0"
 
 if [[ $# -gt 1 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   echo "Usage: scripts/install-validation-tools.sh [destination]"


### PR DESCRIPTION
Refresh the resolved logging dependency and pinned lint tool without changing AXorcist's public API or runtime behavior.

## Dependency changes

- `swift-log`: 1.14.0 → 1.15.0, regenerated with `swift package --scratch-path .build/deps-refresh-20260830 update`. [Upstream notes](https://github.com/apple/swift-log/releases/tag/1.15.0) add public stream-handler initializers, documentation, and build support; the logging paths AXorcist uses are unchanged.
- SwiftLint: 0.65.0 → 0.65.1, including the upstream portable archive SHA-256. The installer downloaded and verified the archive, and strict linting found zero violations. The [removed deprecated option](https://github.com/realm/SwiftLint/releases/tag/0.65.1) is not used here.
- Commander 0.2.4 and SwiftFormat 0.62.1 are already current. Workflow references are current: checkout `v7` resolves to 7.0.1, setup-xcode `v1` to 1.7.0, setup-swift `v1` to 1.14.0, and create-github-app-token is pinned to 3.2.0. No major updates were available or skipped.

## Live proof

Built from this branch on macOS with Apple Swift 6.4 / Xcode 27.0. Commands below execute the newly built binary.

```console
$ .build/deps-refresh-20260830/out/Products/Debug/axorc raw --json '{"command_id":"deps-refresh","command":"ping"}'
{"command_id":"deps-refresh","message":"Ping handled by AXORCCommand. Input source: STDIN","status":"success","success":true}

$ printf '%s\n' '{"command_id":"deps-refresh-stdin","command":"ping"}' | .build/deps-refresh-20260830/out/Products/Debug/axorc raw --stdin
{"command_id":"deps-refresh-stdin","message":"Ping handled by AXORCCommand. Input source: STDIN","status":"success","success":true}

$ .build/deps-refresh-20260830/out/Products/Debug/axorc raw --json '{"command_id":"deps-refresh-trust","command":"isProcessTrusted"}'
{"command_id":"deps-refresh-trust","status":"success","trusted":true}

$ .build/deps-refresh-20260830/out/Products/Debug/axorc raw --json '{"command_id":"deps-refresh-feature","command":"isAXFeatureEnabled"}'
{"command_id":"deps-refresh-feature","enabled":true,"status":"success"}

$ .build/deps-refresh-20260830/out/Products/Debug/axorc tree --app com.apple.dock --depth 1 --role AXApplication --json
{"command_id":"tree","command_type":"collectAll","data":{"count":1,"elements":[{"all_possible_attributes":["AXRole","AXRoleDescription","AXTitle","AXChildren","AXFocusedUIElement","AXEnhancedUserInterface"],"attributes":{"AXDescription":{},"AXIdentifier":{},"AXRole":{"any_value":"AXApplication"},"AXTitle":{"any_value":"Dock"},"AXValue":{}},"brief_description":"Role: AXApplication, PID: 824, Title: 'Dock'","full_ax_description":"Role: AXApplication, PID: 824, Title: 'Dock'","path":["Role: AXApplication, PID: 824, Title: 'Dock'"],"role":"AXApplication","textual_content":"Dock"}]},"status":"success"}
```

## CI reasoning

Default-branch [CI run 33350669492](https://github.com/openclaw/AXorcist/actions/runs/33350669492) was green before this change, including build, formatting/linting, tests, and universal CLI packaging. The existing Swift 6.2.1 / Xcode 16.4 CI compatibility gate is retained in full. ClawSweeper Dispatch is a separate event-driven operations workflow, not build/test CI; its dependencies are already current. No assertions, tests, jobs, or permissions were weakened.

Codex autoreview completed scoped-clean with no accepted/actionable findings at the default P0 threshold.

## Local validation

```console
$ swift build --scratch-path .build/deps-refresh-20260830
Build complete! (380.08 sec)

$ swift test --scratch-path .build/deps-refresh-20260830
Build complete! (133.42 sec)
✔ Test run with 216 tests in 35 suites passed after 15.405 seconds.
✔ Test run with 5 tests in 2 suites passed after 0.002 seconds.

$ PATH="$PWD/.build/deps-refresh-20260830/validation-tools:$PATH" make format-check lint
0/161 files require formatting, 7 files skipped.
Done linting! Found 0 violations, 0 serious in 161 files.

$ bash scripts/test-native-ax-only.sh .build/deps-refresh-20260830/out/Products/Debug/axorc
test-native-ax-only: ok

$ bash scripts/test-native-ax-only-policy.sh
test-native-ax-only-policy: ok

$ shellcheck scripts/*.sh
# Exit 0; no output.
```

The full default test invocation preserves the repository's existing 22 opt-in GUI automation skips. The live Dock query above separately exercises native Accessibility against a running system application. Compiler deprecation warnings come from the existing legacy observer compatibility tests.

```console
$ make test-commander-dependency
# Manifest/cache layout matrix, default/custom resolution, workspace edit/unedit, and root path override all pass.
test-commander-dependency: ok
```

Post-push [PR CI run 33363137372](https://github.com/openclaw/AXorcist/actions/runs/33363137372) passed on commit `1b22e5b293972af139ad35c08041980f03047bd5`, including build, all validation checks, the default test suite, and universal CLI release packaging. The first run was green; no retries were needed.

The separate organization-level [CodeQL run 33363135141](https://github.com/openclaw/AXorcist/actions/runs/33363135141) also passed for Swift, Python, and Actions. Swift analysis completed in 21m24s; the preceding successful default-branch Swift analysis took about 20 minutes. No retries were needed.
