### PR TITLE
fix: preserve timeout cancellation without joining work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to AXorcist will be documented in this file.
 
 ## [0.1.9] - Unreleased
 
+### Fixed
+- Return promptly from async timeouts and caller cancellation without joining uncooperative work, and preserve cancellation received before the result gate is installed. Thanks @SebTardif.
+
 ## [0.1.8] - 2026-08-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -735,6 +735,11 @@ Existing invocations such as `axorc --stdin` and `axorc '{...}'` remain supporte
 
 All operations are MainActor-isolated for thread safety when interacting with the Accessibility API.
 
+`AXTimeoutHelper.withTimeout` runs its async operation concurrently and returns the first result, timeout, or caller
+cancellation without waiting for uncooperative work to finish. Cancellation received before the call starts is preserved
+as `CancellationError`. Timed-out or cancelled work may continue in the background; the helper does not undo its effects.
+Use `Element.withMessagingTimeout` to bound synchronous native Accessibility messages.
+
 ### Performance Optimizations
 
 - Early termination on first match

--- a/Sources/AXorcist/Core/AXTimeoutPolicy.swift
+++ b/Sources/AXorcist/Core/AXTimeoutPolicy.swift
@@ -192,28 +192,70 @@ public struct AXTimeoutWrapper {
 public enum AXTimeoutHelper {
     /// Async timeout helper reused by downstreams (e.g., ScreenCaptureService)
     /// to keep timeout logic in one place.
+    ///
+    /// Returns when `seconds` elapse even if `operation` ignores cancellation.
+    /// The leftover work is asked to cancel but is not joined.
+    /// `operation` is `@concurrent` so `Thread.sleep` cannot hold MainActor
+    /// across the deadline under `defaultIsolation(MainActor.self)`.
     @MainActor
     public static func withTimeout<T: Sendable>(
         seconds: TimeInterval,
-        operation: @escaping @Sendable () async throws -> T) async throws -> T
+        operation: @escaping @concurrent @Sendable () async throws -> T) async throws -> T
     {
-        try await withThrowingTaskGroup(of: T.self) { group in
-            group.addTask {
-                try await operation()
-            }
+        try await self.race(seconds: seconds, operation: operation)
+    }
 
-            group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-                throw AXTimeoutError.operationTimedOut(duration: seconds)
-            }
-
-            guard let result = try await group.next() else {
-                throw AXTimeoutError.operationTimedOut(duration: seconds)
-            }
-
-            group.cancelAll()
-            return result
+    /// Race a deadline against unstructured work. A throwing TaskGroup would
+    /// still join an uncooperative child after the timeout throw.
+    @concurrent
+    private static func race<T: Sendable>(
+        seconds: TimeInterval,
+        operation: @escaping @concurrent @Sendable () async throws -> T) async throws -> T
+    {
+        let timeoutError = AXTimeoutError.operationTimedOut(duration: seconds)
+        let work = Task.detached {
+            try await operation()
         }
+        typealias Gate = FirstResultGate<Result<T, any Error>>
+        let gateBox = OSAllocatedUnfairLock(initialState: (gate: Gate?.none, cancelled: false))
+
+        let result: Result<T, any Error> = await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                let gate = FirstResultGate(continuation: continuation)
+                // Cancellation can arrive before the continuation publishes its gate.
+                let wasCancelled = gateBox.withLock {
+                    $0.gate = gate
+                    return $0.cancelled
+                }
+                if wasCancelled {
+                    gate.finish(with: .failure(CancellationError()), fromTimeout: true)
+                    return
+                }
+                Task.detached {
+                    do {
+                        let value = try await work.value
+                        gate.finish(with: .success(value))
+                    } catch {
+                        gate.finish(with: .failure(error))
+                    }
+                }
+                // GCD timer, not Task.sleep: CI Swift 6.2.1 serialized the
+                // sleeper Task behind the uncooperative work Task.
+                DispatchQueue.global().asyncAfter(deadline: .now() + seconds) {
+                    gate.finish(with: .failure(timeoutError), fromTimeout: true)
+                    work.cancel()
+                }
+            }
+        } onCancel: {
+            let gate = gateBox.withLock {
+                $0.cancelled = true
+                return $0.gate
+            }
+            gate?.finish(with: .failure(CancellationError()), fromTimeout: true)
+            work.cancel()
+        }
+
+        return try result.get()
     }
 }
 

--- a/Tests/AXorcistTests/AXTimeoutHelperTests.swift
+++ b/Tests/AXorcistTests/AXTimeoutHelperTests.swift
@@ -1,6 +1,7 @@
 import ApplicationServices
 import Darwin
 import Foundation
+import os
 import Testing
 @testable import AXorcist
 
@@ -30,6 +31,60 @@ struct AXTimeoutHelperTests {
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
+    }
+
+    @MainActor
+    @Test
+    func `returns without joining uncooperative work`() async {
+        let stillRunning = OSAllocatedUnfairLock(initialState: true)
+        do {
+            _ = try await AXTimeoutHelper.withTimeout(seconds: 0.05) {
+                await Self.sleepIgnoringCancellation(30)
+                stillRunning.withLock { $0 = false }
+                return 1
+            }
+            Issue.record("Expected timeout but succeeded")
+        } catch is AXTimeoutError {
+            // stillRunning is the join proof. Wall-clock bounds flake on
+            // CI when the full 213-test job delays the GCD deadline.
+            #expect(stillRunning.withLock { $0 })
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @MainActor
+    @Test(arguments: [false, true])
+    func `cancellation returns without joining uncooperative work`(alreadyCancelled: Bool) async {
+        let started = ObserverAsyncStartGate()
+        let release = ObserverAsyncStartGate()
+        let finished = ObserverAsyncStartGate()
+        let task = Task { @MainActor in
+            if alreadyCancelled {
+                withUnsafeCurrentTask { $0?.cancel() }
+            }
+            do {
+                // Other suites may occupy MainActor before this test can request cancellation.
+                _ = try await AXTimeoutHelper.withTimeout(seconds: 30) {
+                    started.open()
+                    await release.wait()
+                    finished.open()
+                    return 1
+                }
+                Issue.record("Expected cancellation but succeeded")
+            } catch is CancellationError {
+                // The operation cannot finish until this test opens release.
+            } catch {
+                Issue.record("Expected CancellationError, got \(error)")
+            }
+        }
+        if !alreadyCancelled {
+            await started.wait()
+            task.cancel()
+        }
+        await task.value
+        release.open()
+        await finished.wait()
     }
 
     @Test(arguments: ["windows", "menu bar", "child element"])
@@ -236,6 +291,18 @@ struct AXTimeoutHelperTests {
                 try second.withMessagingTimeout(0.25) { _ in
                     Issue.record("The nested system-wide operation must not run")
                 }
+            }
+        }
+    }
+
+    /// Blocks a background thread. Cancellation does not interrupt this wait.
+    /// Must not Thread.sleep on the caller: CI Swift 6.2.1 still runs the
+    /// `@Sendable` operation on MainActor, which would stall the deadline.
+    private nonisolated static func sleepIgnoringCancellation(_ seconds: TimeInterval) async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global().async {
+                Thread.sleep(forTimeInterval: seconds)
+                cont.resume()
             }
         }
     }


### PR DESCRIPTION
`AXTimeoutHelper.withTimeout` currently waits for cancellation-ignoring work to finish because its task group joins every child. This carries forward @SebTardif's no-join repair from #54 and fixes the remaining cancellation race: cancellation is recorded atomically even before the continuation gate is installed, so an already-cancelled caller receives `CancellationError` immediately.

The operation, deadline, and cancellation still share one first-result gate. Timeout and cancellation request cancellation of the operation without awaiting it. The documentation describes that unfinished work can continue and that synchronous native AX messages need their own messaging deadline.

This maintainer branch is based on current main. The original contribution is from a fork; it remains open, and contributor credit is preserved. No contributor action is requested.

Validation on macOS 26.6.2, Xcode 27 / Swift 6.4:

- The cancellation regression fails against #54's original head with `Expected CancellationError, got Operation timed out after 0.2s`; both cancellation orderings pass with this repair.
- Focused `AXTimeoutHelperTests`: 16 tests passed, including both cancellation cases and native messaging-scope checks.
- Real SwiftPM consumer of the library, running a one-second background thread sleep with a 50 ms timeout:

  ```text
  Before: CASE=already-cancelled RESULT=Operation timed out after 0.05s ELAPSED=0.0552215 seconds STILL_RUNNING=true
  After:  CASE=already-cancelled RESULT=CancellationError ELAPSED=9.5958e-05 seconds STILL_RUNNING=true
  After:  CASE=timeout RESULT=Operation timed out after 0.05s ELAPSED=0.053731541 seconds STILL_RUNNING=true
  SUCCESS=7
  ```

  Command: `swift run --package-path /private/tmp/axorcist-triage-20260831/proof --build-system native --disable-index-store -j 4 TimeoutProof`.
- Full `swift test --build-system native --disable-index-store -j 4`: 223 tests in 37 suites passed. The initial full run exposed scheduling sensitivity in the new cancellation test; its deadline is now deliberately longer than the test workload.
- Repository-pinned SwiftFormat 0.62.1 and strict SwiftLint 0.65.1 passed, as did native-only source/binary checks and policy tests. The first format attempt used local SwiftFormat 0.63.0 and reported unrelated baseline formatting; no baseline source was changed for it. The native-only check used the already-built binary to avoid Xcode 27 default-build/indexing overhead.
- Offline `make test-commander-dependency`: all manifest-cache, default/custom graph, workspace edit/unedit, and root path override cases passed.
- [Hosted compatibility CI](https://github.com/openclaw/AXorcist/actions/runs/33453135674) passed build, lint, tests, and universal CLI packaging.
- Independent Codex autoreview: final change scoped-clean at P0.

This demonstrates the public async helper with uncooperative work, not a wedged AX endpoint or a complete downstream application. Hosted compatibility CI is green; Swift CodeQL and the external bot review were still running at the final local check. Local native-build-system and existing deprecated-API warnings remain.
