### PR TITLE
chore(release): prepare AXorcist 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to AXorcist will be documented in this file.
 
-## [0.1.9] - Unreleased
+## [0.1.9] - 2026-08-31
 
 ### Fixed
 - Keep global application PID and launch-readiness reads off the main actor and outside KVO callbacks, use workspace membership instead of termination queries, and discard stale metadata across stop, restart, and application replacement.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Add to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/openclaw/AXorcist.git", from: "0.1.8")
+    .package(url: "https://github.com/openclaw/AXorcist.git", from: "0.1.9")
 ]
 ```
 

--- a/Sources/axorc/Models/AXORCModels.swift
+++ b/Sources/axorc/Models/AXORCModels.swift
@@ -8,7 +8,7 @@ import Foundation
 
 // MARK: - Version and Configuration
 
-nonisolated let axorcVersion = "0.1.8"
+nonisolated let axorcVersion = "0.1.9"
 
 /// Returns a human-readable build stamp (yyMMddHHmm) evaluated at runtime.
 /// Good enough for confirming we're on the binary we just built.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -9,10 +9,10 @@ The Homebrew formula consumes a Developer ID-signed universal binary. Do not pub
 3. Build with the existing Developer ID Application identity:
 
    ```bash
-   AXORC_CODESIGN_IDENTITY='Developer ID Application: ...' scripts/build-release-artifact.sh 0.1.8
+   AXORC_CODESIGN_IDENTITY='Developer ID Application: ...' scripts/build-release-artifact.sh 0.1.9
    ```
 
-4. Submit `dist/axorc-0.1.8-macos-universal.zip` to `notarytool` using the approved release credentials. Wait for acceptance. Zip archives cannot be stapled; verify the downloaded executable's notarization ticket online after publication.
+4. Submit `dist/axorc-0.1.9-macos-universal.zip` to `notarytool` using the approved release credentials. Wait for acceptance. Zip archives cannot be stapled; verify the downloaded executable's notarization ticket online after publication.
 
 ## Publish and update Homebrew
 
@@ -27,7 +27,7 @@ The Homebrew formula consumes a Developer ID-signed universal binary. Do not pub
 3. Render the formula with the public artifact checksum:
 
    ```bash
-   scripts/render-homebrew-formula.sh 0.1.8 <sha256> > axorc.rb
+   scripts/render-homebrew-formula.sh 0.1.9 <sha256> > axorc.rb
    ```
 
 4. Add `axorc.rb` to `openclaw/homebrew-tap`, then run `brew audit --strict axorc`, `brew install --build-from-source ./axorc.rb`, `axorc --version`, `axorc --help`, and `axorc permissions` on a clean host.


### PR DESCRIPTION
## Summary

Prepare AXorcist 0.1.9 after the workspace-observer and timeout fixes landed. Update the CLI version, date the existing changelog section, and align the current SwiftPM installation and release-command examples. All three fix entries and contributor credit are preserved; no library behavior or dependency changes are included.

## Validation

The versioned candidate `6078e0646a98e4a0c17811df7800b4c58be5b63a` built with Xcode 27, Swift 6.4 and SDK 27, including both the debug/test products and the arm64+x86_64 universal CLI. The debug CLI was signed with the existing Developer ID identity before execution; exact `axorc 0.1.9` output and help checks passed.

The full, unfiltered default suite ran with `swift test --skip-build --disable-automatic-resolution`: 209 named tests passed and 18 automation tests were intentionally skipped. Swift Testing reported 222 tests in 35 suites plus 5 tests in 2 suites. The run had empty stderr and no compiler-warning lines; the earlier build retained existing deprecated-compatibility warnings. All seven test-product hashes were checked after the run, with the six test-bundle files unchanged.

Targeted SwiftFormat, strict SwiftLint, release shell syntax, ShellCheck, Homebrew template Ruby syntax and `git diff --check` passed. The metadata change passed scoped P0 Codex autoreview with no actionable findings. Hosted CI and CodeQL passed on the exact candidate.

The underlying library/dependency tree also has the combined native qualification recorded in [PR #57](https://github.com/openclaw/AXorcist/pull/57#issuecomment-5488959192). That earlier evidence is not relabelled as a versioned release-artifact qualification.

Universal release packaging/signing, notarization, public artifact verification and fresh-install verification remain separate release gates. This PR prepares metadata; it does not tag or publish the release.
