### PR TITLE
fix(release): preserve executable permissions after signing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,12 @@ native-only:
 test-commander-dependency:
 	python3 scripts/test-commander-dependency.py
 
-# Run formatting, linting, native-only policy, and dependency checks
-check: format-check lint native-only test-commander-dependency
+.PHONY: test-universal-binary-mode
+test-universal-binary-mode:
+	@bash scripts/test-universal-binary-mode.sh
+
+# Run formatting, linting, native-only policy, dependency, and binary-mode checks
+check: format-check lint native-only test-commander-dependency test-universal-binary-mode
 	@echo "All code checks complete."
 
 # Default target

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,6 +2,8 @@
 
 The Homebrew formula consumes a Developer ID-signed universal binary. Do not publish the ad-hoc artifact produced by `--adhoc`; a stable signature keeps the macOS Accessibility identity consistent across upgrades.
 
+`scripts/build-universal-binary.sh` restores executable mode `0755` after stripping and signing, regardless of the caller's umask. The release archive preserves that mode. Run `make test-universal-binary-mode` for the source-only permission regression; it mocks build/signing tools and does not replace native signature or archive verification.
+
 ## Prepare
 
 1. Update `axorcVersion` in `Sources/axorc/Models/AXORCModels.swift` and move the changelog entries into the matching release section.

--- a/scripts/build-universal-binary.sh
+++ b/scripts/build-universal-binary.sh
@@ -69,6 +69,9 @@ else
   codesign --force --options runtime --timestamp --sign "$AXORC_CODESIGN_IDENTITY" "$output_path"
 fi
 
+# Rewriting tools can narrow permissions under a restrictive caller umask.
+chmod 0755 "$output_path"
+
 codesign --verify --strict --verbose=2 "$output_path"
 file "$output_path" | grep -q 'universal binary'
 echo "Created universal binary $output_path"

--- a/scripts/test-universal-binary-mode.sh
+++ b/scripts/test-universal-binary-mode.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+builder="$script_dir/build-universal-binary.sh"
+fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/axorcist-binary-mode.XXXXXX")"
+trap 'rm -rf "$fixture_root"' EXIT
+
+mock_bin="$fixture_root/bin"
+mkdir -p "$mock_bin" "$fixture_root/build output"
+# Inert data only: the real builder installs this fixture but never executes it.
+printf '%s\n' 'Not a Mach-O executable; permission fixture only.' >"$fixture_root/build output/axorc"
+chmod 0700 "$fixture_root/build output/axorc"
+
+cat >"$mock_bin/mock-tool" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(umask)" != 0077 ]]; then
+    echo 'Builder widened the caller umask' >&2
+    exit 1
+fi
+
+narrow_mode() {
+    if [[ "$AXORCIST_TEST_NARROW_TOOL" == "$1" ]]; then
+        chmod 0700 "$2"
+        touch "$AXORCIST_TEST_STATE/narrowed"
+    fi
+}
+
+case "${0##*/}" in
+    swift)
+        if [[ " $* " == *' --show-bin-path '* ]]; then
+            printf '%s\n' "$AXORCIST_TEST_BUILD_DIR"
+        fi
+        ;;
+    lipo) ;;
+    strip) narrow_mode strip "${!#}" ;;
+    codesign)
+        case "$1" in
+            --force) narrow_mode codesign "${!#}" ;;
+            --verify) ;;
+            *) exit 2 ;;
+        esac
+        ;;
+    file) printf '%s: universal binary (mock)\n' "$1" ;;
+    *) exit 2 ;;
+esac
+EOF
+chmod +x "$mock_bin/mock-tool"
+for tool in swift lipo strip codesign file; do
+    ln -s mock-tool "$mock_bin/$tool"
+done
+
+failed=0
+for narrow_tool in strip codesign; do
+    for signing_mode in adhoc developer-id; do
+        case_dir="$fixture_root/$narrow_tool-$signing_mode"
+        binary="$case_dir/output directory/axorc"
+        mkdir -p "$case_dir"
+        args=("$binary")
+        if [[ "$signing_mode" == adhoc ]]; then
+            args+=(--adhoc)
+        fi
+        if ! output="$(
+            umask 077
+            env -i \
+                PATH="$mock_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+                AXORC_CODESIGN_IDENTITY='Fixture identity (mock only)' \
+                AXORCIST_TEST_BUILD_DIR="$fixture_root/build output" \
+                AXORCIST_TEST_STATE="$case_dir" \
+                AXORCIST_TEST_NARROW_TOOL="$narrow_tool" \
+                bash "$builder" "${args[@]}" 2>&1
+        )"; then
+            printf 'FAIL: %s/%s builder failed\n%s\n' "$narrow_tool" "$signing_mode" "$output" >&2
+            failed=1
+            continue
+        fi
+        if [[ ! -f "$case_dir/narrowed" ]]; then
+            printf 'FAIL: %s/%s did not exercise the rewrite\n' "$narrow_tool" "$signing_mode" >&2
+            failed=1
+            continue
+        fi
+        mode="$(stat -f '%Lp' "$binary")"
+        if [[ "$mode" != 755 ]]; then
+            printf 'FAIL: %s/%s builder succeeded but output mode is %s; expected 755\n' \
+                "$narrow_tool" "$signing_mode" "$mode" >&2
+            failed=1
+            continue
+        fi
+        printf 'PASS: %s/%s output mode 755 with umask 077\n' "$narrow_tool" "$signing_mode"
+    done
+done
+exit "$failed"


### PR DESCRIPTION
## Summary

Restore the staged executable's `0755` permissions after stripping and signing, before strict signature verification. Keep the caller's umask and all signing options unchanged.

During AXorcist 0.1.9 qualification, a fresh-copy Xcode 27 worker diagnostic reproduced `install -m 0755` → `strip` producing `0700` → the ZIP recording `0100700` under `umask 077`. Successful signing alone therefore did not establish the intended distribution permissions. An owner-only executable is unsuitable for a shared installation.

The fix belongs in the universal binary builder, which owns the output-file contract. Four source-only regression cases simulate permission narrowing by strip or signing in both signing modes. They are wired into `make check`; the release documentation explains the distinction between these tests and native artifact verification.

## Validation

- All four regression cases fail on the previous builder with successful commands but output mode `0700`, then pass after the fix with `0755` and the original private umask retained.
- The unchanged offline Commander dependency-policy suite passed on the qualified Xcode 27 worker in 38.55 seconds, including shared/no-cache matrices, repeated resolution, workspace edits and root path overrides.
- The source-only native-AX policy fixture, ShellCheck, shell syntax checks and `git diff --check` passed.
- Scoped P0 Codex autoreview completed with no findings.

Two additional local dependency-policy attempts timed out at 180 and 900 seconds. They are retained as failed local observations; the worker result does not explain or erase them. An extra local `make native-only` invocation was stopped after it started an unnecessary debug build; the source-only policy fixture was then run explicitly. No result is claimed for that cancelled build.

The original `0700` archive remains unchanged and is not promoted. A fresh archive must pass the existing permission, signature, architecture and release checks before publication. No release or notarization is performed by this PR.
