### PR TITLE
fix: bound observer cleanup admission wait

### DIFF
--- a/Sources/AXorcist/Core/ObserverNativeWork.swift
+++ b/Sources/AXorcist/Core/ObserverNativeWork.swift
@@ -216,6 +216,7 @@ nonisolated enum ObserverNativeWork {
 final nonisolated class ObserverNativeWorkerAdmission: @unchecked Sendable {
     static let maximumConcurrentWorkers = 8
     static let maximumRegularWorkers = ObserverNativeWorkerAdmission.maximumConcurrentWorkers - 1
+    static let cleanupAdmissionTimeout = ObserverNativeWork.notificationWorkTimeout
 
     private let lock = NSLock()
     private var activeWorkerCount = 0
@@ -242,12 +243,7 @@ final nonisolated class ObserverNativeWorkerAdmission: @unchecked Sendable {
         }
     }
 
-    func acquireCleanup() async {
-        let acquired = await self.acquireCleanup(timeout: .seconds(365 * 24 * 60 * 60))
-        precondition(acquired, "unbounded cleanup admission must eventually acquire")
-    }
-
-    func acquireCleanup(timeout: Duration) async -> Bool {
+    func acquireCleanup(timeout: Duration = cleanupAdmissionTimeout) async -> Bool {
         await withCheckedContinuation { continuation in
             let id = UUID()
             let acquired = self.lock.withLock {

--- a/Tests/AXorcistTests/ObserverNativeWorkTests.swift
+++ b/Tests/AXorcistTests/ObserverNativeWorkTests.swift
@@ -15,6 +15,26 @@ struct ObserverNativeWorkTests {
     }
 
     @Test
+    func `cleanup admission timeout matches notification work timeout`() {
+        #expect(
+            ObserverNativeWorkerAdmission.cleanupAdmissionTimeout
+                == ObserverNativeWork.notificationWorkTimeout)
+    }
+
+    @Test
+    func `parameterless cleanup admission fails closed when workers stay saturated`() async {
+        let admission = ObserverNativeWorkerAdmission()
+        for _ in 0..<ObserverNativeWorkerAdmission.maximumConcurrentWorkers {
+            #expect(admission.tryAcquireCleanup())
+        }
+
+        let acquired = await admission.acquireCleanup()
+
+        #expect(!acquired)
+        #expect(admission.activeCount == ObserverNativeWorkerAdmission.maximumConcurrentWorkers)
+    }
+
+    @Test
     func `native observer worker admission is process bounded`() {
         let admission = ObserverNativeWorkerAdmission()
         for _ in 0..<ObserverNativeWorkerAdmission.maximumRegularWorkers {
@@ -36,14 +56,16 @@ struct ObserverNativeWorkTests {
         }
         #expect(admission.tryAcquireCleanup())
         let waiter = Task {
-            await admission.acquireCleanup()
-            return admission.activeCount
+            let acquired = await admission.acquireCleanup()
+            return (acquired, admission.activeCount)
         }
         await Task.yield()
 
         admission.release()
 
-        #expect(await waiter.value == ObserverNativeWorkerAdmission.maximumConcurrentWorkers)
+        let (acquired, count) = await waiter.value
+        #expect(acquired)
+        #expect(count == ObserverNativeWorkerAdmission.maximumConcurrentWorkers)
         admission.release()
     }
 


### PR DESCRIPTION
## What Problem This Solves

`AXObserverCenter.unsubscribe` tears down the last handler by scheduling a native `AXObserverRemoveNotification` through `runPendingCleanup` / `performCleanup`. Worker admission is capped at 8 threads. When those slots are full, a cleanup waiter parks on `acquireCleanup()`.

The parameterless helper used `timeout: .seconds(365 * 24 * 60 * 60)` (31,536,000 seconds) and then `precondition`ed that the wait succeeded. A wedged worker therefore kept unsubscribe cleanup blocked for up to a year. If the wait ever did expire, the process crashed instead of returning `.cannotComplete`.

Add and remove notification work already use a 500ms deadline (`notificationWorkTimeout`, from [#47](https://github.com/openclaw/AXorcist/pull/47)). This default did not.

## Evidence

Live `swift` driver using the same 500ms cleanup-admission deadline production now defaults to. Workers stay saturated, so no slot is granted. The waiter returns `false` instead of sleeping for a year.

```console
$ swift /tmp/prove-cleanup-admission.swift
acquired=false
elapsed=0.533595417 seconds
returned_without_year_wait=true
timeout=0.5 seconds
```

Production default now aliases the notification-work timeout. The year literal and the crash-on-timeout precondition are gone:

```console
$ rg -n "cleanupAdmissionTimeout|365 \* 24|func acquireCleanup|notificationWorkTimeout" Sources/AXorcist/Core/ObserverNativeWork.swift
6:    static let notificationWorkTimeout: Duration = .milliseconds(500)
219:    static let cleanupAdmissionTimeout = ObserverNativeWork.notificationWorkTimeout
246:    func acquireCleanup(timeout: Duration = cleanupAdmissionTimeout) async -> Bool
```

Patched source at [`04129359d59e`](https://github.com/openclaw/AXorcist/commit/04129359d59e2efa7ff81aeeef68a92fd9d54f48).

## Real behavior proof

- **Behavior or issue addressed:** Parameterless observer cleanup admission no longer waits up to a year when native workers are saturated. It uses the same 500ms deadline as add/remove notification work and returns false so unsubscribe cleanup can fail closed instead of blocking teardown or crashing.
- **Real environment tested:** macOS 26.6.2, Apple Swift 6.3.3, patched AXorcist at `/tmp/axorcist-F005` tip [`04129359d59e`](https://github.com/openclaw/AXorcist/commit/04129359d59e2efa7ff81aeeef68a92fd9d54f48).
- **Exact steps or command run after this patch:**

  ```bash
  swift /tmp/prove-cleanup-admission.swift
  rg -n "cleanupAdmissionTimeout|365 \* 24|func acquireCleanup|notificationWorkTimeout" \
    Sources/AXorcist/Core/ObserverNativeWork.swift
  ```

- **Evidence after fix:** terminal output from the patched tree:

  The waiter returns without a year-long sleep:

  ```console
  $ swift /tmp/prove-cleanup-admission.swift
  acquired=false
  elapsed=0.533595417 seconds
  returned_without_year_wait=true
  timeout=0.5 seconds
  ```

  Production source now shares the 500ms notification-work deadline:

  ```console
  $ rg -n "cleanupAdmissionTimeout|func acquireCleanup" Sources/AXorcist/Core/ObserverNativeWork.swift
  219:    static let cleanupAdmissionTimeout = ObserverNativeWork.notificationWorkTimeout
  246:    func acquireCleanup(timeout: Duration = cleanupAdmissionTimeout) async -> Bool
  ```

- **Observed result after fix:** Saturated cleanup admission returns `false` in about half a second. The default timeout is `notificationWorkTimeout` (500ms), not 31,536,000 seconds. A late native remove can still finish and release its slot; the waiter is no longer parked for a year.
- **What was not tested:** Live Accessibility unsubscribe against a wedged third-party app endpoint on a machine with Accessibility permission granted for a real target process.
