### PR TITLE
chore(ci): refresh Swift and SwiftFormat validation tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ permissions:
   statuses: write
 
 env:
-  SWIFT_VERSION: "6.2.1"
+  SWIFT_VERSION: "6.2.4"
   XCODE_VERSION: "16.4"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to AXorcist will be documented in this file.
 
+## Unreleased
+
+### Changed
+- Refresh CI to Swift 6.2.4 and SwiftFormat 0.63.0 while retaining the Swift 6.2 and macOS 14 minimums.
+
 ## [0.1.9] - 2026-08-31
 
 ### Fixed

--- a/Sources/AXorcist/Utils/GeneralParsingUtils.swift
+++ b/Sources/AXorcist/Utils/GeneralParsingUtils.swift
@@ -25,11 +25,11 @@ public func decodeExpectedArray(
                 else if let anyArray = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [Any] {
                     return anyArray.compactMap { item -> String? in
                         if let strItem = item as? String {
-                            return strItem
+                            strItem
                         } else {
                             // For non-string items, convert to string representation
                             // This handles numbers, booleans if they were in the JSON array
-                            return String(describing: item)
+                            String(describing: item)
                         }
                     }
                 }

--- a/scripts/install-validation-tools.sh
+++ b/scripts/install-validation-tools.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-swiftformat_version="0.62.1"
-swiftformat_sha256="7cb1cb1fae04932047c7015441c543848e8e60e1572d808d080e0a1f1661114a"
+swiftformat_version="0.63.0"
+swiftformat_sha256="28c7802e11fa5ae113d903066439c6bb1be20a8ac1ad9709c42616a7e273fb0f"
 swiftlint_version="0.65.1"
 swiftlint_sha256="c1e429b0599cf1b516f369a2d9ec04eaf0e436f3c12b637df8851fa52ff694d0"
 


### PR DESCRIPTION
Refresh validation to Swift 6.2.4 and SwiftFormat 0.63.0. The package retains its Swift 6.2 and macOS 14 minimums, Xcode 16.4 SDK, and existing Commander 0.2.4 / swift-log 1.15.0 pins.

SwiftFormat's updated redundant-return rule requires removing two returns from one `compactMap` closure; the parsing behavior is unchanged. The installer checksum matches the [upstream 0.63.0 artifact digest](https://github.com/nicklockwood/SwiftFormat/releases/tag/0.63.0).

Validation on macOS 26.6.2 / Swift 6.4:

- Validation-tool download checksums and exact versions verified.
- `make check`, `shellcheck scripts/*.sh`, build, and full safe tests passed (222 tests plus 5 command-conversion tests; automation opt-ins skipped).
- Built `axorc` signed with the same Developer ID as the installed CLI: version/help, raw JSON stdin ping, invalid-command exit, Accessibility permission check, and a live native Dock tree query passed.
- Signed universal arm64/x86_64 artifact build, archive contents/checksum, and generated Homebrew formula syntax passed.
- Independent autoreview found no actionable P0–P2 issues.

The PR workflow verifies Swift 6.2.4 and universal CLI packaging before landing. No version bump or publication is included.
