### PR TITLE
fix: bound findWindow AX window listing with a per-element timeout

### DIFF
--- a/Sources/AXorcist/Core/AXWindowResolver.swift
+++ b/Sources/AXorcist/Core/AXWindowResolver.swift
@@ -40,9 +40,25 @@ public final class AXWindowResolver {
     /// Find AX window by CGWindowID in a specific app.
     @MainActor
     public func findWindow(by windowID: CGWindowID, in app: NSRunningApplication) -> Element? {
+        self.findWindow(by: windowID, in: app, messagingTimeout: 2.0)
+    }
+
+    /// Find AX window by CGWindowID across running apps.
+    @MainActor
+    public func findWindow(by windowID: CGWindowID) -> (window: Element, app: NSRunningApplication)? {
+        self.findWindow(by: windowID, messagingTimeout: 2.0)
+    }
+
+    @MainActor
+    func findWindow(
+        by windowID: CGWindowID,
+        in app: NSRunningApplication,
+        messagingTimeout: Float,
+        listWindows: (Element, Float) -> [Element]? = { $0.windowsWithTimeout(timeout: $1) }) -> Element?
+    {
         let appElement = AXUIElementCreateApplication(app.processIdentifier)
         let element = Element(appElement)
-        guard let windows = element.windows() else { return nil }
+        guard let windows = listWindows(element, messagingTimeout) else { return nil }
 
         for window in windows {
             if let currentID = self.windowID(from: window), currentID == windowID {
@@ -52,23 +68,36 @@ public final class AXWindowResolver {
         return nil
     }
 
-    /// Find AX window by CGWindowID across running apps.
     @MainActor
-    public func findWindow(by windowID: CGWindowID) -> (window: Element, app: NSRunningApplication)? {
+    func findWindow(
+        by windowID: CGWindowID,
+        messagingTimeout: Float,
+        listWindows: (Element, Float) -> [Element]? = { $0.windowsWithTimeout(timeout: $1) })
+        -> (window: Element, app: NSRunningApplication)?
+    {
         // Fast path: CoreGraphics owner lookup
         let options: CGWindowListOption = [.optionIncludingWindow]
         if let windowInfoList = CGWindowListCopyWindowInfo(options, windowID) as? [[String: Any]],
            let windowInfo = windowInfoList.first,
            let ownerPID = windowInfo[kCGWindowOwnerPID as String] as? pid_t,
            let app = NSWorkspace.shared.runningApplications.first(where: { $0.processIdentifier == ownerPID }),
-           let window = self.findWindow(by: windowID, in: app)
+           let window = self.findWindow(
+               by: windowID,
+               in: app,
+               messagingTimeout: messagingTimeout,
+               listWindows: listWindows)
         {
             return (window, app)
         }
 
         // Fallback: full AX enumeration (works without Screen Recording permission).
         for app in NSWorkspace.shared.runningApplications {
-            if let window = self.findWindow(by: windowID, in: app) {
+            if let window = self.findWindow(
+                by: windowID,
+                in: app,
+                messagingTimeout: messagingTimeout,
+                listWindows: listWindows)
+            {
                 return (window, app)
             }
         }

--- a/Tests/AXorcistTests/AXWindowResolverTests.swift
+++ b/Tests/AXorcistTests/AXWindowResolverTests.swift
@@ -19,4 +19,30 @@ struct AXWindowResolverTests {
     func `windowExists false for random ID`() {
         #expect(self.resolver.windowExists(windowID: 999_999_999) == false)
     }
+
+    @Test
+    @MainActor
+    func `findWindow asks the window list with the requested messaging timeout`() {
+        var seenTimeout: Float?
+        let result = self.resolver.findWindow(
+            by: 1,
+            in: NSRunningApplication.current,
+            messagingTimeout: 1.25)
+        { _, timeout in
+            seenTimeout = timeout
+            return nil
+        }
+
+        #expect(result == nil)
+        #expect(seenTimeout == 1.25)
+    }
+
+    @Test(arguments: [Float.zero, -0.1, Float.infinity, Float.nan])
+    @MainActor
+    func `findWindow returns nil when the messaging timeout is invalid`(timeout: Float) {
+        #expect(self.resolver.findWindow(
+            by: 1,
+            in: NSRunningApplication.current,
+            messagingTimeout: timeout) == nil)
+    }
 }


### PR DESCRIPTION
Public `AXWindowResolver.findWindow` now lists an app's AX windows through the existing per-element messaging timeout instead of an unbounded `windows()` call.

## What Problem This Solves

`findWindow(by:in:)` asked `element.windows()` with no Accessibility messaging deadline. The CGWindowID-only overload then walks every `NSWorkspace` app through that same path. One wedged AX server leaves MainActor blocked for the life of the scan, so any Peekaboo or CLI caller waiting on window lookup never returns.

`windowsWithTimeout` already exists in this module and arms a per-element `AXUIElementSetMessagingTimeout`. This change uses that helper (default 2s). It does not set a process-wide system-wide deadline.

## Evidence

Terminal output from a live `swift run` of a tiny client that imports the patched `AXorcist` library (`/tmp/prove-ax-f006`, depends on `/tmp/axorcist-f006`):

```console
$ swift run
missingID_nil=true
elapsed_ms=0.70
windowsWithTimeout_0_nil=true
windowsWithTimeout_neg_nil=true
windowsWithTimeout_nan_nil=true
```

A missing window ID returns in under a millisecond. Invalid messaging timeouts (`0`, negative, NaN) skip the AX list and return nil instead of calling unbounded `windows()`.

## Real behavior proof

- **Behavior or issue addressed:** `findWindow` hung MainActor on a wedged `element.windows()`; lookup now uses per-element `windowsWithTimeout` (2s default) and fail-closes on an invalid timeout.
- **Real environment tested:** macOS 26, Apple Swift 6.3.3, patched AXorcist at `/tmp/axorcist-f006`, live client at `/tmp/prove-ax-f006`.
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/prove-ax-f006
  swift run
  ```

- **Evidence after fix:** terminal output from the patched library:

  ```console
  $ swift run
  missingID_nil=true
  elapsed_ms=0.70
  windowsWithTimeout_0_nil=true
  windowsWithTimeout_neg_nil=true
  windowsWithTimeout_nan_nil=true
  ```

- **Observed result after fix:** `findWindow(by: 1, in: currentApp)` returned nil in 0.70ms. `windowsWithTimeout` with `0`, `-1`, and NaN returned nil without an unbounded AX list.
- **What was not tested:** a live wedged Accessibility server; `_AXUIElementGetWindow` after the timed list; Screen Recording-denied CG owner lookup versus the all-apps fallback.

## Origin

Introduced in [`89cbe7a2`](https://github.com/openclaw/AXorcist/commit/89cbe7a2) (2025-11-19, Peter Steinberger, "Add AX wrappers and input driver coverage"). Present for 290 days.

## Related

- [AXorcist #39](https://github.com/openclaw/AXorcist/pull/39) added fail-closed `windowsWithTimeout` / messaging-scope ownership.
- [AXorcist #55](https://github.com/openclaw/AXorcist/pull/55) rejected a system-wide `AXTimeoutWrapper` deadline without registry ownership. This PR uses the per-element helper from #39 instead.
- [AXorcist #59](https://github.com/openclaw/AXorcist/pull/59) landed no-join `withTimeout` for a different public helper.
